### PR TITLE
Clear page content to prevent overflow

### DIFF
--- a/.dev/sass/components/_typography.scss
+++ b/.dev/sass/components/_typography.scss
@@ -96,6 +96,7 @@ code {
 
 pre {
 	padding: 1em;
+	overflow-x: scroll;
 }
 
 cite {

--- a/.dev/sass/layouts/_clearings.scss
+++ b/.dev/sass/layouts/_clearings.scss
@@ -1,5 +1,6 @@
 .clear,
-.page-content:after {
+.page-content:after,
+.entry-content:after {
 	@include clearfix;
 	@include clearfix-after;
 }

--- a/.dev/sass/layouts/_clearings.scss
+++ b/.dev/sass/layouts/_clearings.scss
@@ -1,0 +1,5 @@
+.clear,
+.page-content:after {
+	@include clearfix;
+	@include clearfix-after;
+}

--- a/.dev/sass/layouts/_posts.scss
+++ b/.dev/sass/layouts/_posts.scss
@@ -57,6 +57,7 @@
 }
 
 .nav-links {
+	width: 100%;
 	@include clearfix;
 
 	.nav-previous {

--- a/.dev/sass/style.scss
+++ b/.dev/sass/style.scss
@@ -37,6 +37,7 @@
 @import "components/typography";
 @import "components/wp-classes";
 
+@import "layouts/clearings";
 @import "layouts/footer";
 @import "layouts/header";
 @import "layouts/hero";

--- a/editor-style-rtl.css
+++ b/editor-style-rtl.css
@@ -269,7 +269,8 @@ code {
   padding: 5px; }
 
 pre {
-  padding: 1em; }
+  padding: 1em;
+  overflow-x: scroll; }
 
 cite {
   display: inline-block;

--- a/editor-style.css
+++ b/editor-style.css
@@ -269,7 +269,8 @@ code {
   padding: 5px; }
 
 pre {
-  padding: 1em; }
+  padding: 1em;
+  overflow-x: scroll; }
 
 cite {
   display: inline-block;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1763,6 +1763,7 @@ body.no-max-width .main-navigation {
   content: '\f300'; }
 
 .nav-links {
+  width: 100%;
   content: "";
   display: table;
   table-layout: fixed; }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1178,7 +1178,8 @@ code {
   padding: 5px; }
 
 pre {
-  padding: 1em; }
+  padding: 1em;
+  overflow-x: scroll; }
 
 cite {
   display: inline-block;
@@ -1297,7 +1298,8 @@ blockquote {
   outline: 0; }
 
 .clear,
-.page-content:after {
+.page-content:after,
+.entry-content:after {
   content: "";
   display: table;
   table-layout: fixed;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1296,6 +1296,13 @@ blockquote {
 #content[tabindex="-1"]:focus {
   outline: 0; }
 
+.clear,
+.page-content:after {
+  content: "";
+  display: table;
+  table-layout: fixed;
+  clear: both; }
+
 .site-footer {
   background-color: #404c4e; }
 

--- a/style.css
+++ b/style.css
@@ -1763,6 +1763,7 @@ body.no-max-width .main-navigation {
   content: '\f300'; }
 
 .nav-links {
+  width: 100%;
   content: "";
   display: table;
   table-layout: fixed; }

--- a/style.css
+++ b/style.css
@@ -1178,7 +1178,8 @@ code {
   padding: 5px; }
 
 pre {
-  padding: 1em; }
+  padding: 1em;
+  overflow-x: scroll; }
 
 cite {
   display: inline-block;
@@ -1297,7 +1298,8 @@ blockquote {
   outline: 0; }
 
 .clear,
-.page-content:after {
+.page-content:after,
+.entry-content:after {
   content: "";
   display: table;
   table-layout: fixed;

--- a/style.css
+++ b/style.css
@@ -1296,6 +1296,13 @@ blockquote {
 #content[tabindex="-1"]:focus {
   outline: 0; }
 
+.clear,
+.page-content:after {
+  content: "";
+  display: table;
+  table-layout: fixed;
+  clear: both; }
+
 .site-footer {
   background-color: #404c4e; }
 


### PR DESCRIPTION
- Clear page and post content to prevent overflow when the last element is has a `float`.
- Set the `<pre>` tags to overflow-x: scroll, to prevent overflows. (edge case)