### PR TITLE
Site header styles

### DIFF
--- a/.dev/sass/layouts/_header.scss
+++ b/.dev/sass/layouts/_header.scss
@@ -32,10 +32,20 @@
 .site-title {
 	font-size: 1.333em;
 	height: 100px;
+	line-height: 100px;
 	margin: 0 0 0 1.25em;
 	text-transform: uppercase;
-	display: table-cell;
 	vertical-align: middle;
+
+	@media #{$large-up} {
+		display: table-cell;
+		line-height: 1.333em;
+	}
+	@media #{$small-only} {
+		display: table-cell;
+		line-height: 1.333em;
+		padding: 0 65px 0 15px;
+	}
 }
 
 .site-description {

--- a/.dev/sass/layouts/_header.scss
+++ b/.dev/sass/layouts/_header.scss
@@ -32,9 +32,10 @@
 .site-title {
 	font-size: 1.333em;
 	height: 100px;
-	line-height: 100px;
 	margin: 0 0 0 1.25em;
 	text-transform: uppercase;
+	display: table-cell;
+	vertical-align: middle;
 }
 
 .site-description {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1471,10 +1471,19 @@ blockquote {
 .site-title {
   font-size: 1.333em;
   height: 100px;
+  line-height: 100px;
   margin: 0 1.25em 0 0;
   text-transform: uppercase;
-  display: table-cell;
   vertical-align: middle; }
+  @media only screen and (min-width: 61.063em) {
+    .site-title {
+      display: table-cell;
+      line-height: 1.333em; } }
+  @media only screen and (max-width: 40.063em) {
+    .site-title {
+      display: table-cell;
+      line-height: 1.333em;
+      padding: 0 15px 0 65px; } }
 
 .site-description {
   display: none; }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1471,9 +1471,10 @@ blockquote {
 .site-title {
   font-size: 1.333em;
   height: 100px;
-  line-height: 100px;
   margin: 0 1.25em 0 0;
-  text-transform: uppercase; }
+  text-transform: uppercase;
+  display: table-cell;
+  vertical-align: middle; }
 
 .site-description {
   display: none; }

--- a/style.css
+++ b/style.css
@@ -1471,9 +1471,10 @@ blockquote {
 .site-title {
   font-size: 1.333em;
   height: 100px;
-  line-height: 100px;
   margin: 0 0 0 1.25em;
-  text-transform: uppercase; }
+  text-transform: uppercase;
+  display: table-cell;
+  vertical-align: middle; }
 
 .site-description {
   display: none; }

--- a/style.css
+++ b/style.css
@@ -1471,10 +1471,19 @@ blockquote {
 .site-title {
   font-size: 1.333em;
   height: 100px;
+  line-height: 100px;
   margin: 0 0 0 1.25em;
   text-transform: uppercase;
-  display: table-cell;
   vertical-align: middle; }
+  @media only screen and (min-width: 61.063em) {
+    .site-title {
+      display: table-cell;
+      line-height: 1.333em; } }
+  @media only screen and (max-width: 40.063em) {
+    .site-title {
+      display: table-cell;
+      line-height: 1.333em;
+      padding: 0 65px 0 15px; } }
 
 .site-description {
   display: none; }


### PR DESCRIPTION
Fixes #11 

Tweak header styles to allow for multi line site titles. Adjusts for break points as well.

Screenshots (with patch applied):

![Single line site title](https://cldup.com/U6kvUcqFuC.png)
![Two line site title](https://cldup.com/LCfHTlMg7t.png)
![Three line site title](https://cldup.com/5kEZaFD0Bz.png)