### PR TITLE
Update Primer hook priorities 

### DIFF
--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -6,7 +6,6 @@
 }
 
 .main-navigation .menu-item-object-cart a {
-    padding-left: 0;
     float: right;
     cursor: pointer;
 }

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -1,116 +1,171 @@
-/**
- * Custom Shopping Cart Menu Item
- */
-.main-navigation .menu-item-object-cart {
-    float: right;
-}
-
-.main-navigation .menu-item-object-cart a {
-    float: right;
-    cursor: pointer;
-}
-
-.main-navigation .menu-item-object-cart a i {
-    font-size: 20px;
-}
-
 .main-navigation .menu-item-object-cart:hover a {
-    background: transparent;
-}
-
-.main-navigation .menu-item-object-cart .cart-preview-total {
-    float: left;
-    margin-right: 1rem;
-    font-weight: bold;
-}
-
-.main-navigation .menu-item-object-cart .cart-preview-count {
-    float: left;
-    font-weight: 200;
+	background: transparent;
 }
 
 ul.site-header-cart.menu {
-    width: 100%;
-    max-width: 275px;
-    padding: 0;
-    list-style: none;
-    float: right;
-    display: none;
-    position: relative;
-    z-index: 10001;
-		background: $base-background-color;
+	width: 100%;
+	max-width: 275px;
+	padding: 0;
+	list-style: none;
+	float: right;
+	display: none;
+	position: relative;
+	z-index: 10001;
 }
 
-ul.site-header-cart.menu li {
-    border: none, 1px solid grey, 1px solid grey, 1px solid grey;
-    -webkit-box-shadow: 0 0 10px 0 grey;
-    box-shadow: 0 0 10px 0 grey;
+.site-footer-inner .woocommerce-cart-menu-item,
+.site-info-wrapper .woocommerce-cart-menu-item {
+	display: none;
 }
 
-ul.site-header-cart.menu ul.product_list_widget li {
-    border: none;
-    -webkit-box-shadow: none;
-    box-shadow: none;
+.widget_shopping_cart {
+
+	float: left;
+	padding: 0 1rem;
+	margin-bottom: .5em;
+
+	.quantity {
+		display: block;
+		float: left;
+		font-style: italic;
+		padding-left: .75em;
+	}
+
+	ul.product_list_widget {
+		position: relative !important;
+		left: 0;
+	}
+
+	p.buttons,
+	.total,
+	.product_list_widget {
+		float: left;
+		width: 100%;
+	}
+
+	.total strong {
+		text-index: 0;
+	}
+
+	p.buttons {
+		padding: .5em;
+		margin: 0;
+	}
+
 }
 
-ul.site-header-cart.menu .widget_shopping_cart {
-    margin-bottom: 0;
-    padding: 10px 0 2px 0;
+.woocommerce-cart-menu-item .sub-menu {
+	background: transparent;
 }
 
-ul.site-header-cart.menu .widget_shopping_cart .product_list_widget {
-    padding: 0 .5em;
-    max-height: 220px;
-    overflow-y: auto;
+.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
+	padding: 0 !important;
+	margin: 0;
+	width: 100%;
+	padding-bottom: 5px;
+	border-bottom: none;
+	padding: .5em 1em;
+	text-indent: 0;
+	opacity: 1;
+	transition: opacity .25s ease-out;
+	-moz-transition: opacity .25s ease-out;
+	-webkit-transition: opacity .25s ease-out;
+	-o-transition: opacity .25s ease-out;
+
+	img {
+		width: 100%;
+		max-width: 55px;
+	}
+
+	a {
+		border-bottom: none;
+	}
+
+	a:nth-child(2) {
+		padding: .5em;
+		margin: 0;
+		width: 100%;
+		text-indent: 0 !important;
+	}
+
+	&:hover {
+		opacity: .85;
+	}
 }
 
-ul.site-header-cart.menu .widget_shopping_cart .product_list_widget img.attachment-shop_thumbnail {
-    width: 55px;
-    -webkit-border-radius: 5px;
-    border-radius: 5px;
+.woocommerce-cart-menu-item {
+
+	.product_list_widget {
+		border: none;
+		box-shadow: none;
+		display: inline-block;
+		left: 0 !important;
+		background: inherit;
+	}
+
+	.widget_shopping_cart {
+
+		padding: 0;
+		margin-bottom: 0;
+
+		.total {
+			margin: 0 0 10px 0;
+			padding-top: 10px;
+			text-align: center;
+		}
+
+		.total strong {
+			text-indent: 0;
+		}
+
+		p.buttons a {
+			text-align: center;
+			width: 100%;
+			text-indent: 0;
+
+			&:first-child {
+				margin-bottom: 5px;
+			}
+
+		}
+
+	}
+
+	.cart-preview-count {
+		margin-left: 8px;
+	}
+
+	.cart_list li a.remove {
+		position: relative !important;
+		float: left;
+		padding: 0;
+		margin-top: 10px;
+		margin-left: 15px;
+		text-indent: 0;
+		margin-right: 5px;
+		z-index: 1001;
+		line-height: .8;
+		text-indent: 0 !important;
+		border: none;
+		box-shadow: none;
+
+		&:hover {
+			background: red !important;
+		}
+	}
+
 }
 
-ul.site-header-cart.menu .widget_shopping_cart .total {
-    padding: 10px;
-    margin: .5em 0;
+li#woocommerce-cart-menu-item li.mini_cart_item a {
+	border-bottom: none;
+	text-indent: 15px;
+	color: inherit;
 }
 
-ul.site-header-cart.menu .widget_shopping_cart .buttons {
-    padding: 0 .5em;
-    margin: 0;
-}
+@media #{$medium-up} {
 
-ul.site-header-cart.menu .widget_shopping_cart .buttons a {
-    display: block;
-    width: 100%;
-    text-align: center;
-}
+	li#woocommerce-cart-menu-item .sub-menu {
+		margin-left: -6em;
+	}
 
-ul.site-header-cart.menu .widget_shopping_cart .buttons a.remove {
-	padding-top: 2px;
-}
-
-.site-header-cart-container {
-    width: 100%;
-    display: block;
-    max-width: 1100px;
-    margin: 0 auto;
-    position: absolute;
-    right: 0;
-    left: 0;
-		top: 100%;
-}
-
-.site-header-cart-container .buttons a {
-    margin-bottom: 5px;
-}
-
-body.woocommerce .quantity input.input-text.qty {
-	padding: .45em;
-}
-
-@media only screen and (max-width: 61.063em) {
-    .menu-item-object-cart {
-        display: none;
-    }
 }

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -54,6 +54,10 @@ ul.site-header-cart.menu {
 
 }
 
+.woocommerce-cart-menu-item:hover {
+	cursor: pointer;
+}
+
 .woocommerce-cart-menu-item .sub-menu {
 	background: transparent;
 }

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -202,6 +202,12 @@ body.single-product {
 	padding: 10px;
 }
 
+.woocommerce ul.products li.product a.add_to_cart_button {
+	width: 100%;
+	font-size: 16px;
+	text-align: center;
+}
+
 @media #{$small-only} {
 
 	.primer-wc-cart-menu {

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -8,7 +8,7 @@
 		li,
 		.widget_shopping_cart {
 			width: 100%;
-			background: #fff;
+			background: inherit;
 		}
 
 		.widget_shopping_cart {
@@ -21,7 +21,8 @@
 				display: block;
 				float: left;
 				font-style: italic;
-				padding-left: .75em;
+				font-size: small;
+				margin-left: 2.6em;
 			}
 
 			ul.product_list_widget {
@@ -44,12 +45,12 @@
 
 			p.buttons {
 				padding: .5em;
+				padding-top: 0;
 				margin: 0;
 			}
 
 			.cart_list li.mini_cart_item {
 				padding: 0 !important;
-				margin: 0;
 				width: 100%;
 				padding-bottom: 5px;
 				border-bottom: none;
@@ -61,6 +62,7 @@
 				img {
 					width: 100%;
 					max-width: 55px;
+					margin-bottom: 0;
 				}
 
 				a {
@@ -69,6 +71,7 @@
 
 				a:nth-child(2) {
 					padding: .5em;
+					padding-bottom: 5px;
 					margin: 0;
 					width: 100%;
 					text-indent: 0 !important;
@@ -76,6 +79,10 @@
 
 				&:hover {
 					opacity: .85;
+				}
+
+				&:last-child {
+					margin-bottom: 10px;
 				}
 			}
 
@@ -97,8 +104,8 @@
 				margin-bottom: 0;
 
 				.total {
-					margin: 0 0 10px 0;
-					padding-top: 10px;
+					margin: 0;
+					padding: 10px 0;
 					text-align: center;
 				}
 
@@ -128,7 +135,7 @@
 				float: left;
 				padding: 0;
 				margin-top: 10px;
-				margin-left: 15px;
+				margin-left: 5px;
 				text-indent: 0;
 				margin-right: 5px;
 				z-index: 1001;
@@ -194,20 +201,23 @@ body.woocommerce-cart {
 	}
 }
 
-.woocommerce #content table.cart img,
-.woocommerce table.cart img,
-.woocommerce-page #content table.cart img,
-.woocommerce-page table.cart img {
-	width: 100%;
-	max-width: 100px;
-	margin-bottom: 0;
-}
+.woocommerce,
+.woocommerce-page {
 
-.woocommerce #content table.cart td.actions .input-text,
-.woocommerce table.cart td.actions .input-text,
-.woocommerce-page #content table.cart td.actions .input-text,
-.woocommerce-page table.cart td.actions .input-text {
-	padding: 10px;
+	table.cart {
+
+		img {
+			width: 100%;
+			max-width: 100px;
+			margin-bottom: 0;
+		}
+
+		td.actions .input-text {
+			padding: 10px !important;
+		}
+
+	}
+
 }
 
 .woocommerce ul.products li.product a.add_to_cart_button {

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -1,0 +1,117 @@
+/**
+ * Custom Shopping Cart Menu Item
+ */
+.main-navigation .menu-item-object-cart {
+    float: right;
+}
+
+.main-navigation .menu-item-object-cart a {
+    padding-left: 0;
+    float: right;
+    cursor: pointer;
+}
+
+.main-navigation .menu-item-object-cart a i {
+    font-size: 20px;
+}
+
+.main-navigation .menu-item-object-cart:hover a {
+    background: transparent;
+}
+
+.main-navigation .menu-item-object-cart .cart-preview-total {
+    float: left;
+    margin-right: 1rem;
+    font-weight: bold;
+}
+
+.main-navigation .menu-item-object-cart .cart-preview-count {
+    float: left;
+    font-weight: 200;
+}
+
+ul.site-header-cart.menu {
+    width: 100%;
+    max-width: 275px;
+    padding: 0;
+    list-style: none;
+    float: right;
+    display: none;
+    position: relative;
+    z-index: 10001;
+		background: $base-background-color;
+}
+
+ul.site-header-cart.menu li {
+    border: none, 1px solid grey, 1px solid grey, 1px solid grey;
+    -webkit-box-shadow: 0 0 10px 0 grey;
+    box-shadow: 0 0 10px 0 grey;
+}
+
+ul.site-header-cart.menu ul.product_list_widget li {
+    border: none;
+    -webkit-box-shadow: none;
+    box-shadow: none;
+}
+
+ul.site-header-cart.menu .widget_shopping_cart {
+    margin-bottom: 0;
+    padding: 10px 0 2px 0;
+}
+
+ul.site-header-cart.menu .widget_shopping_cart .product_list_widget {
+    padding: 0 .5em;
+    max-height: 220px;
+    overflow-y: auto;
+}
+
+ul.site-header-cart.menu .widget_shopping_cart .product_list_widget img.attachment-shop_thumbnail {
+    width: 55px;
+    -webkit-border-radius: 5px;
+    border-radius: 5px;
+}
+
+ul.site-header-cart.menu .widget_shopping_cart .total {
+    padding: 10px;
+    margin: .5em 0;
+}
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons {
+    padding: 0 .5em;
+    margin: 0;
+}
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons a {
+    display: block;
+    width: 100%;
+    text-align: center;
+}
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons a.remove {
+	padding-top: 2px;
+}
+
+.site-header-cart-container {
+    width: 100%;
+    display: block;
+    max-width: 1100px;
+    margin: 0 auto;
+    position: absolute;
+    right: 0;
+    left: 0;
+		top: 100%;
+}
+
+.site-header-cart-container .buttons a {
+    margin-bottom: 5px;
+}
+
+body.woocommerce .quantity input.input-text.qty {
+	padding: .45em;
+}
+
+@media only screen and (max-width: 61.063em) {
+    .menu-item-object-cart {
+        display: none;
+    }
+}

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -34,6 +34,8 @@ ul.site-header-cart.menu {
 	ul.product_list_widget {
 		position: relative !important;
 		left: 0;
+		max-height: 250px;
+		overflow-y: auto;
 	}
 
 	p.buttons,
@@ -164,6 +166,32 @@ li#woocommerce-cart-menu-item li.mini_cart_item a {
 	border-bottom: none;
 	text-indent: 15px;
 	color: inherit;
+}
+
+body.post-type-archive,
+body.single-product {
+
+	/* On Sale Badge */
+	span.onsale,
+	ul.products li.product .onsale {
+		padding: 2px 8px;
+		border-radius: 0;
+		margin: 0;
+		min-height: auto;
+		min-width: auto;
+		line-height: inherit;
+	}
+
+}
+
+body.single-product {
+
+	span.onsale {
+		padding: 3px 18px;
+		top: 0;
+		left: 0;
+	}
+
 }
 
 @media #{$medium-up} {

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -187,11 +187,19 @@ body.single-product {
 
 }
 
+body.woocommerce-cart {
+
+	.primer-wc-cart-sub-menu {
+		display: none;
+	}
+}
+
 .woocommerce #content table.cart img,
 .woocommerce table.cart img,
 .woocommerce-page #content table.cart img,
 .woocommerce-page table.cart img {
 	width: 100%;
+	max-width: 100px;
 	margin-bottom: 0;
 }
 

--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -1,171 +1,160 @@
-.main-navigation .menu-item-object-cart:hover a {
-	background: transparent;
-}
+.primer-wc-cart-menu {
 
-ul.site-header-cart.menu {
-	width: 100%;
-	max-width: 275px;
-	padding: 0;
-	list-style: none;
-	float: right;
-	display: none;
-	position: relative;
-	z-index: 10001;
-}
-
-.site-footer-inner .woocommerce-cart-menu-item,
-.site-info-wrapper .woocommerce-cart-menu-item {
-	display: none;
-}
-
-.widget_shopping_cart {
-
-	float: left;
-	padding: 0 1rem;
-	margin-bottom: .5em;
-
-	.quantity {
-		display: block;
-		float: left;
-		font-style: italic;
-		padding-left: .75em;
-	}
-
-	ul.product_list_widget {
-		position: relative !important;
-		left: 0;
-		max-height: 250px;
-		overflow-y: auto;
-	}
-
-	p.buttons,
-	.total,
-	.product_list_widget {
-		float: left;
+	.primer-wc-cart-sub-menu {
+		float: right;
 		width: 100%;
-	}
-
-	.total strong {
-		text-index: 0;
-	}
-
-	p.buttons {
-		padding: .5em;
-		margin: 0;
-	}
-
-}
-
-.woocommerce-cart-menu-item:hover {
-	cursor: pointer;
-}
-
-.woocommerce-cart-menu-item .sub-menu {
-	background: transparent;
-}
-
-.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
-	padding: 0 !important;
-	margin: 0;
-	width: 100%;
-	padding-bottom: 5px;
-	border-bottom: none;
-	padding: .5em 1em;
-	text-indent: 0;
-	opacity: 1;
-	transition: opacity .25s ease-out;
-	-moz-transition: opacity .25s ease-out;
-	-webkit-transition: opacity .25s ease-out;
-	-o-transition: opacity .25s ease-out;
-
-	img {
-		width: 100%;
-		max-width: 55px;
-	}
-
-	a {
-		border-bottom: none;
-	}
-
-	a:nth-child(2) {
-		padding: .5em;
-		margin: 0;
-		width: 100%;
-		text-indent: 0 !important;
-	}
-
-	&:hover {
-		opacity: .85;
-	}
-}
-
-.woocommerce-cart-menu-item {
-
-	.product_list_widget {
-		border: none;
 		box-shadow: none;
-		display: inline-block;
-		left: 0 !important;
-		background: inherit;
-	}
 
-	.widget_shopping_cart {
-
-		padding: 0;
-		margin-bottom: 0;
-
-		.total {
-			margin: 0 0 10px 0;
-			padding-top: 10px;
-			text-align: center;
-		}
-
-		.total strong {
-			text-indent: 0;
-		}
-
-		p.buttons a {
-			text-align: center;
+		li,
+		.widget_shopping_cart {
 			width: 100%;
-			text-indent: 0;
+			background: #fff;
+		}
 
-			&:first-child {
-				margin-bottom: 5px;
+		.widget_shopping_cart {
+
+			float: right;
+			width: 250px;
+			box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2);
+
+			.quantity {
+				display: block;
+				float: left;
+				font-style: italic;
+				padding-left: .75em;
+			}
+
+			ul.product_list_widget {
+				position: relative !important;
+				left: 0;
+				max-height: 250px;
+				overflow-y: auto;
+			}
+
+			p.buttons,
+			.total,
+			.product_list_widget {
+				float: left;
+				width: 100%;
+			}
+
+			.total strong {
+				text-index: 0;
+			}
+
+			p.buttons {
+				padding: .5em;
+				margin: 0;
+			}
+
+			.cart_list li.mini_cart_item {
+				padding: 0 !important;
+				margin: 0;
+				width: 100%;
+				padding-bottom: 5px;
+				border-bottom: none;
+				padding: .5em 1em;
+				text-indent: 0;
+				opacity: 1;
+				transition: opacity .25s ease-out;
+
+				img {
+					width: 100%;
+					max-width: 55px;
+				}
+
+				a {
+					border-bottom: none;
+				}
+
+				a:nth-child(2) {
+					padding: .5em;
+					margin: 0;
+					width: 100%;
+					text-indent: 0 !important;
+				}
+
+				&:hover {
+					opacity: .85;
+				}
+			}
+
+		}
+
+		.primer-wc-cart-sub-menu-item {
+
+			.product_list_widget {
+				border: none;
+				box-shadow: none;
+				display: inline-block;
+				left: 0 !important;
+				background: inherit;
+			}
+
+			.widget_shopping_cart {
+
+				padding: 0;
+				margin-bottom: 0;
+
+				.total {
+					margin: 0 0 10px 0;
+					padding-top: 10px;
+					text-align: center;
+				}
+
+				.total strong {
+					text-indent: 0;
+				}
+
+				p.buttons a {
+					text-align: center;
+					width: 100%;
+					text-indent: 0;
+
+					&:first-child {
+						margin-bottom: 5px;
+					}
+
+				}
+
+			}
+
+			.cart-preview-count {
+				margin-left: 8px;
+			}
+
+			.cart_list li a.remove {
+				position: relative !important;
+				float: left;
+				padding: 0;
+				margin-top: 10px;
+				margin-left: 15px;
+				text-indent: 0;
+				margin-right: 5px;
+				z-index: 1001;
+				line-height: 1;
+				text-indent: 0 !important;
+				border: none;
+				box-shadow: none;
+
+				&:hover {
+					background: red !important;
+				}
 			}
 
 		}
 
 	}
 
-	.cart-preview-count {
-		margin-left: 8px;
-	}
+	&:hover {
+		cursor: pointer;
 
-	.cart_list li a.remove {
-		position: relative !important;
-		float: left;
-		padding: 0;
-		margin-top: 10px;
-		margin-left: 15px;
-		text-indent: 0;
-		margin-right: 5px;
-		z-index: 1001;
-		line-height: .8;
-		text-indent: 0 !important;
-		border: none;
-		box-shadow: none;
-
-		&:hover {
-			background: red !important;
+		a {
+			background: transparent;
 		}
+
 	}
 
-}
-
-li#woocommerce-cart-menu-item li.mini_cart_item a {
-	border-bottom: none;
-	text-indent: 15px;
-	color: inherit;
 }
 
 body.post-type-archive,
@@ -192,12 +181,39 @@ body.single-product {
 		left: 0;
 	}
 
+	.quantity .input-text {
+		padding: 8px;
+	}
+
 }
 
-@media #{$medium-up} {
+.woocommerce #content table.cart img,
+.woocommerce table.cart img,
+.woocommerce-page #content table.cart img,
+.woocommerce-page table.cart img {
+	width: 100%;
+	margin-bottom: 0;
+}
 
-	li#woocommerce-cart-menu-item .sub-menu {
-		margin-left: -6em;
+.woocommerce #content table.cart td.actions .input-text,
+.woocommerce table.cart td.actions .input-text,
+.woocommerce-page #content table.cart td.actions .input-text,
+.woocommerce-page table.cart td.actions .input-text {
+	padding: 10px;
+}
+
+@media #{$small-only} {
+
+	.primer-wc-cart-menu {
+
+		.primer-wc-cart-sub-menu {
+
+			.widget_shopping_cart {
+				width: 100%;
+			}
+
+		}
+
 	}
 
 }

--- a/.dev/sass/layouts/_menu.scss
+++ b/.dev/sass/layouts/_menu.scss
@@ -26,7 +26,6 @@
 
 	.expand {
 		font-size: 1.8rem;
-		color: white;
 		position: absolute;
 		right: 0;
 		top: 0;

--- a/.dev/sass/style.scss
+++ b/.dev/sass/style.scss
@@ -44,3 +44,4 @@
 @import "layouts/menu";
 @import "layouts/posts";
 @import "layouts/sidebar";
+@import "compat/woocommerce";

--- a/functions.php
+++ b/functions.php
@@ -20,11 +20,9 @@ function stout_move_elements() {
 	remove_action( 'primer_header',       'primer_add_hero',               7 );
 	remove_action( 'primer_after_header', 'primer_add_primary_navigation', 11 );
 	remove_action( 'primer_after_header', 'primer_add_page_title',         12 );
-	remove_action( 'primer_after_header', 'primer_generate_cart_submenu',  11 );
 
 	add_action( 'primer_after_header', 'primer_add_hero',               7 );
 	add_action( 'primer_header',       'primer_add_primary_navigation', 11 );
-	add_action( 'primer_header',       'primer_generate_cart_submenu',  12 );
 
 	if ( ! is_front_page() || ! is_active_sidebar( 'hero' ) ) {
 

--- a/functions.php
+++ b/functions.php
@@ -17,16 +17,16 @@ define( 'PRIMER_CHILD_VERSION', '1.0.0' );
  */
 function stout_move_elements() {
 
-	remove_action( 'primer_header',       'primer_add_hero' );
-	remove_action( 'primer_after_header', 'primer_add_primary_navigation' );
-	remove_action( 'primer_after_header', 'primer_add_page_title' );
+	remove_action( 'primer_header',       'primer_add_hero',               7 );
+	remove_action( 'primer_after_header', 'primer_add_primary_navigation', 11 );
+	remove_action( 'primer_after_header', 'primer_add_page_title',         12 );
 
-	add_action( 'primer_after_header', 'primer_add_hero' );
-	add_action( 'primer_header',       'primer_add_primary_navigation' );
+	add_action( 'primer_after_header', 'primer_add_hero',               7 );
+	add_action( 'primer_header',       'primer_add_primary_navigation', 11 );
 
 	if ( ! is_front_page() || ! is_active_sidebar( 'hero' ) ) {
 
-		add_action( 'primer_hero', 'primer_add_page_title' );
+		add_action( 'primer_hero', 'primer_add_page_title', 12 );
 
 	}
 

--- a/functions.php
+++ b/functions.php
@@ -20,9 +20,11 @@ function stout_move_elements() {
 	remove_action( 'primer_header',       'primer_add_hero',               7 );
 	remove_action( 'primer_after_header', 'primer_add_primary_navigation', 11 );
 	remove_action( 'primer_after_header', 'primer_add_page_title',         12 );
+	remove_action( 'primer_after_header', 'primer_generate_cart_submenu',  11 );
 
 	add_action( 'primer_after_header', 'primer_add_hero',               7 );
 	add_action( 'primer_header',       'primer_add_primary_navigation', 11 );
+	add_action( 'primer_header',       'primer_generate_cart_submenu',  12 );
 
 	if ( ! is_front_page() || ! is_active_sidebar( 'hero' ) ) {
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1838,6 +1838,9 @@ ul.site-header-cart.menu {
     padding: .5em;
     margin: 0; }
 
+.woocommerce-cart-menu-item:hover {
+  cursor: pointer; }
+
 .woocommerce-cart-menu-item .sub-menu {
   background: transparent; }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1805,7 +1805,7 @@ body.no-max-width .main-navigation {
   .primer-wc-cart-menu .primer-wc-cart-sub-menu li,
   .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {
     width: 100%;
-    background: #fff; }
+    background: inherit; }
   .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {
     float: left;
     width: 250px;
@@ -1815,7 +1815,8 @@ body.no-max-width .main-navigation {
       display: block;
       float: right;
       font-style: italic;
-      padding-right: .75em; }
+      font-size: small;
+      margin-right: 2.6em; }
     .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart ul.product_list_widget {
       position: relative !important;
       right: 0;
@@ -1830,10 +1831,10 @@ body.no-max-width .main-navigation {
       text-index: 0; }
     .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart p.buttons {
       padding: .5em;
+      padding-top: 0;
       margin: 0; }
     .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item {
       padding: 0 !important;
-      margin: 0;
       width: 100%;
       padding-bottom: 5px;
       border-bottom: none;
@@ -1844,16 +1845,20 @@ body.no-max-width .main-navigation {
       transition: opacity .25s ease-out; }
       .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item img {
         width: 100%;
-        max-width: 55px; }
+        max-width: 55px;
+        margin-bottom: 0; }
       .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item a {
         border-bottom: none; }
       .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
         padding: .5em;
+        padding-bottom: 5px;
         margin: 0;
         width: 100%;
         text-indent: 0 !important; }
       .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item:hover {
         opacity: .85; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item:last-child {
+        margin-bottom: 10px; }
   .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .product_list_widget {
     border: none;
     -webkit-box-shadow: none;
@@ -1865,8 +1870,8 @@ body.no-max-width .main-navigation {
     padding: 0;
     margin-bottom: 0; }
     .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart .total {
-      margin: 0 0 10px 0;
-      padding-top: 10px;
+      margin: 0;
+      padding: 10px 0;
       text-align: center; }
     .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart .total strong {
       text-indent: 0; }
@@ -1883,7 +1888,7 @@ body.no-max-width .main-navigation {
     float: right;
     padding: 0;
     margin-top: 10px;
-    margin-right: 15px;
+    margin-right: 5px;
     text-indent: 0;
     margin-left: 5px;
     z-index: 1001;
@@ -1926,19 +1931,15 @@ body.single-product .quantity .input-text {
 body.woocommerce-cart .primer-wc-cart-sub-menu {
   display: none; }
 
-.woocommerce #content table.cart img,
 .woocommerce table.cart img,
-.woocommerce-page #content table.cart img,
 .woocommerce-page table.cart img {
   width: 100%;
   max-width: 100px;
   margin-bottom: 0; }
 
-.woocommerce #content table.cart td.actions .input-text,
 .woocommerce table.cart td.actions .input-text,
-.woocommerce-page #content table.cart td.actions .input-text,
 .woocommerce-page table.cart td.actions .input-text {
-  padding: 10px; }
+  padding: 10px !important; }
 
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1923,11 +1923,15 @@ body.single-product span.onsale {
 body.single-product .quantity .input-text {
   padding: 8px; }
 
+body.woocommerce-cart .primer-wc-cart-sub-menu {
+  display: none; }
+
 .woocommerce #content table.cart img,
 .woocommerce table.cart img,
 .woocommerce-page #content table.cart img,
 .woocommerce-page table.cart img {
   width: 100%;
+  max-width: 100px;
   margin-bottom: 0; }
 
 .woocommerce #content table.cart td.actions .input-text,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1826,7 +1826,9 @@ ul.site-header-cart.menu {
     padding-right: .75em; }
   .widget_shopping_cart ul.product_list_widget {
     position: relative !important;
-    right: 0; }
+    right: 0;
+    max-height: 250px;
+    overflow-y: auto; }
   .widget_shopping_cart p.buttons,
   .widget_shopping_cart .total,
   .widget_shopping_cart .product_list_widget {
@@ -1918,6 +1920,26 @@ li#woocommerce-cart-menu-item li.mini_cart_item a {
   border-bottom: none;
   text-indent: 15px;
   color: inherit; }
+
+body.post-type-archive,
+body.single-product {
+  /* On Sale Badge */ }
+  body.post-type-archive span.onsale,
+  body.post-type-archive ul.products li.product .onsale,
+  body.single-product span.onsale,
+  body.single-product ul.products li.product .onsale {
+    padding: 2px 8px;
+    -webkit-border-radius: 0;
+    border-radius: 0;
+    margin: 0;
+    min-height: auto;
+    min-width: auto;
+    line-height: inherit; }
+
+body.single-product span.onsale {
+  padding: 3px 18px;
+  top: 0;
+  right: 0; }
 
 @media only screen and (min-width: 40.063em) {
   li#woocommerce-cart-menu-item .sub-menu {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1798,30 +1798,8 @@ body.no-max-width .main-navigation {
 .widget_recent_entries .post-date {
   display: block; }
 
-/**
- * Custom Shopping Cart Menu Item
- */
-.main-navigation .menu-item-object-cart {
-  float: left; }
-
-.main-navigation .menu-item-object-cart a {
-  float: left;
-  cursor: pointer; }
-
-.main-navigation .menu-item-object-cart a i {
-  font-size: 20px; }
-
 .main-navigation .menu-item-object-cart:hover a {
   background: transparent; }
-
-.main-navigation .menu-item-object-cart .cart-preview-total {
-  float: right;
-  margin-left: 1rem;
-  font-weight: bold; }
-
-.main-navigation .menu-item-object-cart .cart-preview-count {
-  float: right;
-  font-weight: 200; }
 
 ul.site-header-cart.menu {
   width: 100%;
@@ -1831,65 +1809,113 @@ ul.site-header-cart.menu {
   float: left;
   display: none;
   position: relative;
-  z-index: 10001;
-  background: #e3eaeb; }
+  z-index: 10001; }
 
-ul.site-header-cart.menu li {
-  border: none, 1px solid grey, 1px solid grey, 1px solid grey;
-  -webkit-box-shadow: 0 0 10px 0 grey;
-  box-shadow: 0 0 10px 0 grey; }
+.site-footer-inner .woocommerce-cart-menu-item,
+.site-info-wrapper .woocommerce-cart-menu-item {
+  display: none; }
 
-ul.site-header-cart.menu ul.product_list_widget li {
+.widget_shopping_cart {
+  float: right;
+  padding: 0 1rem;
+  margin-bottom: .5em; }
+  .widget_shopping_cart .quantity {
+    display: block;
+    float: right;
+    font-style: italic;
+    padding-right: .75em; }
+  .widget_shopping_cart ul.product_list_widget {
+    position: relative !important;
+    right: 0; }
+  .widget_shopping_cart p.buttons,
+  .widget_shopping_cart .total,
+  .widget_shopping_cart .product_list_widget {
+    float: right;
+    width: 100%; }
+  .widget_shopping_cart .total strong {
+    text-index: 0; }
+  .widget_shopping_cart p.buttons {
+    padding: .5em;
+    margin: 0; }
+
+.woocommerce-cart-menu-item .sub-menu {
+  background: transparent; }
+
+.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
+  padding: 0 !important;
+  margin: 0;
+  width: 100%;
+  padding-bottom: 5px;
+  border-bottom: none;
+  padding: .5em 1em;
+  text-indent: 0;
+  opacity: 1;
+  transition: opacity .25s ease-out;
+  -moz-transition: opacity .25s ease-out;
+  -webkit-transition: opacity .25s ease-out;
+  -o-transition: opacity .25s ease-out; }
+  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item img {
+    width: 100%;
+    max-width: 55px; }
+  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a {
+    border-bottom: none; }
+  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
+    padding: .5em;
+    margin: 0;
+    width: 100%;
+    text-indent: 0 !important; }
+  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item:hover {
+    opacity: .85; }
+
+.woocommerce-cart-menu-item .product_list_widget {
+  border: none;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  display: inline-block;
+  right: 0 !important;
+  background: inherit; }
+
+.woocommerce-cart-menu-item .widget_shopping_cart {
+  padding: 0;
+  margin-bottom: 0; }
+  .woocommerce-cart-menu-item .widget_shopping_cart .total {
+    margin: 0 0 10px 0;
+    padding-top: 10px;
+    text-align: center; }
+  .woocommerce-cart-menu-item .widget_shopping_cart .total strong {
+    text-indent: 0; }
+  .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a {
+    text-align: center;
+    width: 100%;
+    text-indent: 0; }
+    .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a:first-child {
+      margin-bottom: 5px; }
+
+.woocommerce-cart-menu-item .cart-preview-count {
+  margin-right: 8px; }
+
+.woocommerce-cart-menu-item .cart_list li a.remove {
+  position: relative !important;
+  float: right;
+  padding: 0;
+  margin-top: 10px;
+  margin-right: 15px;
+  text-indent: 0;
+  margin-left: 5px;
+  z-index: 1001;
+  line-height: .8;
+  text-indent: 0 !important;
   border: none;
   -webkit-box-shadow: none;
   box-shadow: none; }
+  .woocommerce-cart-menu-item .cart_list li a.remove:hover {
+    background: red !important; }
 
-ul.site-header-cart.menu .widget_shopping_cart {
-  margin-bottom: 0;
-  padding: 10px 0 2px 0; }
+li#woocommerce-cart-menu-item li.mini_cart_item a {
+  border-bottom: none;
+  text-indent: 15px;
+  color: inherit; }
 
-ul.site-header-cart.menu .widget_shopping_cart .product_list_widget {
-  padding: 0 .5em;
-  max-height: 220px;
-  overflow-y: auto; }
-
-ul.site-header-cart.menu .widget_shopping_cart .product_list_widget img.attachment-shop_thumbnail {
-  width: 55px;
-  -webkit-border-radius: 5px;
-  border-radius: 5px; }
-
-ul.site-header-cart.menu .widget_shopping_cart .total {
-  padding: 10px;
-  margin: .5em 0; }
-
-ul.site-header-cart.menu .widget_shopping_cart .buttons {
-  padding: 0 .5em;
-  margin: 0; }
-
-ul.site-header-cart.menu .widget_shopping_cart .buttons a {
-  display: block;
-  width: 100%;
-  text-align: center; }
-
-ul.site-header-cart.menu .widget_shopping_cart .buttons a.remove {
-  padding-top: 2px; }
-
-.site-header-cart-container {
-  width: 100%;
-  display: block;
-  max-width: 1100px;
-  margin: 0 auto;
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 100%; }
-
-.site-header-cart-container .buttons a {
-  margin-bottom: 5px; }
-
-body.woocommerce .quantity input.input-text.qty {
-  padding: .45em; }
-
-@media only screen and (max-width: 61.063em) {
-  .menu-item-object-cart {
-    display: none; } }
+@media only screen and (min-width: 40.063em) {
+  li#woocommerce-cart-menu-item .sub-menu {
+    margin-right: -6em; } }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1936,6 +1936,11 @@ body.single-product .quantity .input-text {
 .woocommerce-page table.cart td.actions .input-text {
   padding: 10px; }
 
+.woocommerce ul.products li.product a.add_to_cart_button {
+  width: 100%;
+  font-size: 16px;
+  text-align: center; }
+
 @media only screen and (max-width: 40.063em) {
   .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {
     width: 100%; } }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1797,3 +1797,100 @@ body.no-max-width .main-navigation {
 
 .widget_recent_entries .post-date {
   display: block; }
+
+/**
+ * Custom Shopping Cart Menu Item
+ */
+.main-navigation .menu-item-object-cart {
+  float: left; }
+
+.main-navigation .menu-item-object-cart a {
+  padding-right: 0;
+  float: left;
+  cursor: pointer; }
+
+.main-navigation .menu-item-object-cart a i {
+  font-size: 20px; }
+
+.main-navigation .menu-item-object-cart:hover a {
+  background: transparent; }
+
+.main-navigation .menu-item-object-cart .cart-preview-total {
+  float: right;
+  margin-left: 1rem;
+  font-weight: bold; }
+
+.main-navigation .menu-item-object-cart .cart-preview-count {
+  float: right;
+  font-weight: 200; }
+
+ul.site-header-cart.menu {
+  width: 100%;
+  max-width: 275px;
+  padding: 0;
+  list-style: none;
+  float: left;
+  display: none;
+  position: relative;
+  z-index: 10001;
+  background: #e3eaeb; }
+
+ul.site-header-cart.menu li {
+  border: none, 1px solid grey, 1px solid grey, 1px solid grey;
+  -webkit-box-shadow: 0 0 10px 0 grey;
+  box-shadow: 0 0 10px 0 grey; }
+
+ul.site-header-cart.menu ul.product_list_widget li {
+  border: none;
+  -webkit-box-shadow: none;
+  box-shadow: none; }
+
+ul.site-header-cart.menu .widget_shopping_cart {
+  margin-bottom: 0;
+  padding: 10px 0 2px 0; }
+
+ul.site-header-cart.menu .widget_shopping_cart .product_list_widget {
+  padding: 0 .5em;
+  max-height: 220px;
+  overflow-y: auto; }
+
+ul.site-header-cart.menu .widget_shopping_cart .product_list_widget img.attachment-shop_thumbnail {
+  width: 55px;
+  -webkit-border-radius: 5px;
+  border-radius: 5px; }
+
+ul.site-header-cart.menu .widget_shopping_cart .total {
+  padding: 10px;
+  margin: .5em 0; }
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons {
+  padding: 0 .5em;
+  margin: 0; }
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons a {
+  display: block;
+  width: 100%;
+  text-align: center; }
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons a.remove {
+  padding-top: 2px; }
+
+.site-header-cart-container {
+  width: 100%;
+  display: block;
+  max-width: 1100px;
+  margin: 0 auto;
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 100%; }
+
+.site-header-cart-container .buttons a {
+  margin-bottom: 5px; }
+
+body.woocommerce .quantity input.input-text.qty {
+  padding: .45em; }
+
+@media only screen and (max-width: 61.063em) {
+  .menu-item-object-cart {
+    display: none; } }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1568,7 +1568,6 @@ blockquote {
         z-index: 9999; } }
   .main-navigation .expand {
     font-size: 1.8rem;
-    color: white;
     position: absolute;
     left: 0;
     top: 0;
@@ -1798,128 +1797,108 @@ body.no-max-width .main-navigation {
 .widget_recent_entries .post-date {
   display: block; }
 
-.main-navigation .menu-item-object-cart:hover a {
-  background: transparent; }
-
-ul.site-header-cart.menu {
-  width: 100%;
-  max-width: 275px;
-  padding: 0;
-  list-style: none;
+.primer-wc-cart-menu .primer-wc-cart-sub-menu {
   float: left;
-  display: none;
-  position: relative;
-  z-index: 10001; }
-
-.site-footer-inner .woocommerce-cart-menu-item,
-.site-info-wrapper .woocommerce-cart-menu-item {
-  display: none; }
-
-.widget_shopping_cart {
-  float: right;
-  padding: 0 1rem;
-  margin-bottom: .5em; }
-  .widget_shopping_cart .quantity {
-    display: block;
-    float: right;
-    font-style: italic;
-    padding-right: .75em; }
-  .widget_shopping_cart ul.product_list_widget {
-    position: relative !important;
-    right: 0;
-    max-height: 250px;
-    overflow-y: auto; }
-  .widget_shopping_cart p.buttons,
-  .widget_shopping_cart .total,
-  .widget_shopping_cart .product_list_widget {
-    float: right;
-    width: 100%; }
-  .widget_shopping_cart .total strong {
-    text-index: 0; }
-  .widget_shopping_cart p.buttons {
-    padding: .5em;
-    margin: 0; }
-
-.woocommerce-cart-menu-item:hover {
-  cursor: pointer; }
-
-.woocommerce-cart-menu-item .sub-menu {
-  background: transparent; }
-
-.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
-  padding: 0 !important;
-  margin: 0;
   width: 100%;
-  padding-bottom: 5px;
-  border-bottom: none;
-  padding: .5em 1em;
-  text-indent: 0;
-  opacity: 1;
-  transition: opacity .25s ease-out;
-  -moz-transition: opacity .25s ease-out;
-  -webkit-transition: opacity .25s ease-out;
-  -o-transition: opacity .25s ease-out; }
-  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item img {
-    width: 100%;
-    max-width: 55px; }
-  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a {
-    border-bottom: none; }
-  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
-    padding: .5em;
-    margin: 0;
-    width: 100%;
-    text-indent: 0 !important; }
-  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item:hover {
-    opacity: .85; }
-
-.woocommerce-cart-menu-item .product_list_widget {
-  border: none;
-  -webkit-box-shadow: none;
-  box-shadow: none;
-  display: inline-block;
-  right: 0 !important;
-  background: inherit; }
-
-.woocommerce-cart-menu-item .widget_shopping_cart {
-  padding: 0;
-  margin-bottom: 0; }
-  .woocommerce-cart-menu-item .widget_shopping_cart .total {
-    margin: 0 0 10px 0;
-    padding-top: 10px;
-    text-align: center; }
-  .woocommerce-cart-menu-item .widget_shopping_cart .total strong {
-    text-indent: 0; }
-  .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a {
-    text-align: center;
-    width: 100%;
-    text-indent: 0; }
-    .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a:first-child {
-      margin-bottom: 5px; }
-
-.woocommerce-cart-menu-item .cart-preview-count {
-  margin-right: 8px; }
-
-.woocommerce-cart-menu-item .cart_list li a.remove {
-  position: relative !important;
-  float: right;
-  padding: 0;
-  margin-top: 10px;
-  margin-right: 15px;
-  text-indent: 0;
-  margin-left: 5px;
-  z-index: 1001;
-  line-height: .8;
-  text-indent: 0 !important;
-  border: none;
   -webkit-box-shadow: none;
   box-shadow: none; }
-  .woocommerce-cart-menu-item .cart_list li a.remove:hover {
-    background: red !important; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu li,
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {
+    width: 100%;
+    background: #fff; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {
+    float: left;
+    width: 250px;
+    -webkit-box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2); }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .quantity {
+      display: block;
+      float: right;
+      font-style: italic;
+      padding-right: .75em; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart ul.product_list_widget {
+      position: relative !important;
+      right: 0;
+      max-height: 250px;
+      overflow-y: auto; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart p.buttons,
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .total,
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .product_list_widget {
+      float: right;
+      width: 100%; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .total strong {
+      text-index: 0; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart p.buttons {
+      padding: .5em;
+      margin: 0; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item {
+      padding: 0 !important;
+      margin: 0;
+      width: 100%;
+      padding-bottom: 5px;
+      border-bottom: none;
+      padding: .5em 1em;
+      text-indent: 0;
+      opacity: 1;
+      -webkit-transition: opacity .25s ease-out;
+      transition: opacity .25s ease-out; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item img {
+        width: 100%;
+        max-width: 55px; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item a {
+        border-bottom: none; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
+        padding: .5em;
+        margin: 0;
+        width: 100%;
+        text-indent: 0 !important; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item:hover {
+        opacity: .85; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .product_list_widget {
+    border: none;
+    -webkit-box-shadow: none;
+    box-shadow: none;
+    display: inline-block;
+    right: 0 !important;
+    background: inherit; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart {
+    padding: 0;
+    margin-bottom: 0; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart .total {
+      margin: 0 0 10px 0;
+      padding-top: 10px;
+      text-align: center; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart .total strong {
+      text-indent: 0; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart p.buttons a {
+      text-align: center;
+      width: 100%;
+      text-indent: 0; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart p.buttons a:first-child {
+        margin-bottom: 5px; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .cart-preview-count {
+    margin-right: 8px; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .cart_list li a.remove {
+    position: relative !important;
+    float: right;
+    padding: 0;
+    margin-top: 10px;
+    margin-right: 15px;
+    text-indent: 0;
+    margin-left: 5px;
+    z-index: 1001;
+    line-height: 1;
+    text-indent: 0 !important;
+    border: none;
+    -webkit-box-shadow: none;
+    box-shadow: none; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .cart_list li a.remove:hover {
+      background: red !important; }
 
-li#woocommerce-cart-menu-item li.mini_cart_item a {
-  border-bottom: none;
-  text-indent: 15px;
-  color: inherit; }
+.primer-wc-cart-menu:hover {
+  cursor: pointer; }
+  .primer-wc-cart-menu:hover a {
+    background: transparent; }
 
 body.post-type-archive,
 body.single-product {
@@ -1941,6 +1920,22 @@ body.single-product span.onsale {
   top: 0;
   right: 0; }
 
-@media only screen and (min-width: 40.063em) {
-  li#woocommerce-cart-menu-item .sub-menu {
-    margin-right: -6em; } }
+body.single-product .quantity .input-text {
+  padding: 8px; }
+
+.woocommerce #content table.cart img,
+.woocommerce table.cart img,
+.woocommerce-page #content table.cart img,
+.woocommerce-page table.cart img {
+  width: 100%;
+  margin-bottom: 0; }
+
+.woocommerce #content table.cart td.actions .input-text,
+.woocommerce table.cart td.actions .input-text,
+.woocommerce-page #content table.cart td.actions .input-text,
+.woocommerce-page table.cart td.actions .input-text {
+  padding: 10px; }
+
+@media only screen and (max-width: 40.063em) {
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {
+    width: 100%; } }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1805,7 +1805,6 @@ body.no-max-width .main-navigation {
   float: left; }
 
 .main-navigation .menu-item-object-cart a {
-  padding-right: 0;
   float: left;
   cursor: pointer; }
 

--- a/style.css
+++ b/style.css
@@ -1838,6 +1838,9 @@ ul.site-header-cart.menu {
     padding: .5em;
     margin: 0; }
 
+.woocommerce-cart-menu-item:hover {
+  cursor: pointer; }
+
 .woocommerce-cart-menu-item .sub-menu {
   background: transparent; }
 

--- a/style.css
+++ b/style.css
@@ -1923,11 +1923,15 @@ body.single-product span.onsale {
 body.single-product .quantity .input-text {
   padding: 8px; }
 
+body.woocommerce-cart .primer-wc-cart-sub-menu {
+  display: none; }
+
 .woocommerce #content table.cart img,
 .woocommerce table.cart img,
 .woocommerce-page #content table.cart img,
 .woocommerce-page table.cart img {
   width: 100%;
+  max-width: 100px;
   margin-bottom: 0; }
 
 .woocommerce #content table.cart td.actions .input-text,

--- a/style.css
+++ b/style.css
@@ -1797,3 +1797,100 @@ body.no-max-width .main-navigation {
 
 .widget_recent_entries .post-date {
   display: block; }
+
+/**
+ * Custom Shopping Cart Menu Item
+ */
+.main-navigation .menu-item-object-cart {
+  float: right; }
+
+.main-navigation .menu-item-object-cart a {
+  padding-left: 0;
+  float: right;
+  cursor: pointer; }
+
+.main-navigation .menu-item-object-cart a i {
+  font-size: 20px; }
+
+.main-navigation .menu-item-object-cart:hover a {
+  background: transparent; }
+
+.main-navigation .menu-item-object-cart .cart-preview-total {
+  float: left;
+  margin-right: 1rem;
+  font-weight: bold; }
+
+.main-navigation .menu-item-object-cart .cart-preview-count {
+  float: left;
+  font-weight: 200; }
+
+ul.site-header-cart.menu {
+  width: 100%;
+  max-width: 275px;
+  padding: 0;
+  list-style: none;
+  float: right;
+  display: none;
+  position: relative;
+  z-index: 10001;
+  background: #e3eaeb; }
+
+ul.site-header-cart.menu li {
+  border: none, 1px solid grey, 1px solid grey, 1px solid grey;
+  -webkit-box-shadow: 0 0 10px 0 grey;
+  box-shadow: 0 0 10px 0 grey; }
+
+ul.site-header-cart.menu ul.product_list_widget li {
+  border: none;
+  -webkit-box-shadow: none;
+  box-shadow: none; }
+
+ul.site-header-cart.menu .widget_shopping_cart {
+  margin-bottom: 0;
+  padding: 10px 0 2px 0; }
+
+ul.site-header-cart.menu .widget_shopping_cart .product_list_widget {
+  padding: 0 .5em;
+  max-height: 220px;
+  overflow-y: auto; }
+
+ul.site-header-cart.menu .widget_shopping_cart .product_list_widget img.attachment-shop_thumbnail {
+  width: 55px;
+  -webkit-border-radius: 5px;
+  border-radius: 5px; }
+
+ul.site-header-cart.menu .widget_shopping_cart .total {
+  padding: 10px;
+  margin: .5em 0; }
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons {
+  padding: 0 .5em;
+  margin: 0; }
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons a {
+  display: block;
+  width: 100%;
+  text-align: center; }
+
+ul.site-header-cart.menu .widget_shopping_cart .buttons a.remove {
+  padding-top: 2px; }
+
+.site-header-cart-container {
+  width: 100%;
+  display: block;
+  max-width: 1100px;
+  margin: 0 auto;
+  position: absolute;
+  right: 0;
+  left: 0;
+  top: 100%; }
+
+.site-header-cart-container .buttons a {
+  margin-bottom: 5px; }
+
+body.woocommerce .quantity input.input-text.qty {
+  padding: .45em; }
+
+@media only screen and (max-width: 61.063em) {
+  .menu-item-object-cart {
+    display: none; } }

--- a/style.css
+++ b/style.css
@@ -1805,7 +1805,6 @@ body.no-max-width .main-navigation {
   float: right; }
 
 .main-navigation .menu-item-object-cart a {
-  padding-left: 0;
   float: right;
   cursor: pointer; }
 

--- a/style.css
+++ b/style.css
@@ -1798,30 +1798,8 @@ body.no-max-width .main-navigation {
 .widget_recent_entries .post-date {
   display: block; }
 
-/**
- * Custom Shopping Cart Menu Item
- */
-.main-navigation .menu-item-object-cart {
-  float: right; }
-
-.main-navigation .menu-item-object-cart a {
-  float: right;
-  cursor: pointer; }
-
-.main-navigation .menu-item-object-cart a i {
-  font-size: 20px; }
-
 .main-navigation .menu-item-object-cart:hover a {
   background: transparent; }
-
-.main-navigation .menu-item-object-cart .cart-preview-total {
-  float: left;
-  margin-right: 1rem;
-  font-weight: bold; }
-
-.main-navigation .menu-item-object-cart .cart-preview-count {
-  float: left;
-  font-weight: 200; }
 
 ul.site-header-cart.menu {
   width: 100%;
@@ -1831,65 +1809,113 @@ ul.site-header-cart.menu {
   float: right;
   display: none;
   position: relative;
-  z-index: 10001;
-  background: #e3eaeb; }
+  z-index: 10001; }
 
-ul.site-header-cart.menu li {
-  border: none, 1px solid grey, 1px solid grey, 1px solid grey;
-  -webkit-box-shadow: 0 0 10px 0 grey;
-  box-shadow: 0 0 10px 0 grey; }
+.site-footer-inner .woocommerce-cart-menu-item,
+.site-info-wrapper .woocommerce-cart-menu-item {
+  display: none; }
 
-ul.site-header-cart.menu ul.product_list_widget li {
+.widget_shopping_cart {
+  float: left;
+  padding: 0 1rem;
+  margin-bottom: .5em; }
+  .widget_shopping_cart .quantity {
+    display: block;
+    float: left;
+    font-style: italic;
+    padding-left: .75em; }
+  .widget_shopping_cart ul.product_list_widget {
+    position: relative !important;
+    left: 0; }
+  .widget_shopping_cart p.buttons,
+  .widget_shopping_cart .total,
+  .widget_shopping_cart .product_list_widget {
+    float: left;
+    width: 100%; }
+  .widget_shopping_cart .total strong {
+    text-index: 0; }
+  .widget_shopping_cart p.buttons {
+    padding: .5em;
+    margin: 0; }
+
+.woocommerce-cart-menu-item .sub-menu {
+  background: transparent; }
+
+.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
+  padding: 0 !important;
+  margin: 0;
+  width: 100%;
+  padding-bottom: 5px;
+  border-bottom: none;
+  padding: .5em 1em;
+  text-indent: 0;
+  opacity: 1;
+  transition: opacity .25s ease-out;
+  -moz-transition: opacity .25s ease-out;
+  -webkit-transition: opacity .25s ease-out;
+  -o-transition: opacity .25s ease-out; }
+  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item img {
+    width: 100%;
+    max-width: 55px; }
+  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a {
+    border-bottom: none; }
+  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
+    padding: .5em;
+    margin: 0;
+    width: 100%;
+    text-indent: 0 !important; }
+  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item:hover {
+    opacity: .85; }
+
+.woocommerce-cart-menu-item .product_list_widget {
+  border: none;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  display: inline-block;
+  left: 0 !important;
+  background: inherit; }
+
+.woocommerce-cart-menu-item .widget_shopping_cart {
+  padding: 0;
+  margin-bottom: 0; }
+  .woocommerce-cart-menu-item .widget_shopping_cart .total {
+    margin: 0 0 10px 0;
+    padding-top: 10px;
+    text-align: center; }
+  .woocommerce-cart-menu-item .widget_shopping_cart .total strong {
+    text-indent: 0; }
+  .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a {
+    text-align: center;
+    width: 100%;
+    text-indent: 0; }
+    .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a:first-child {
+      margin-bottom: 5px; }
+
+.woocommerce-cart-menu-item .cart-preview-count {
+  margin-left: 8px; }
+
+.woocommerce-cart-menu-item .cart_list li a.remove {
+  position: relative !important;
+  float: left;
+  padding: 0;
+  margin-top: 10px;
+  margin-left: 15px;
+  text-indent: 0;
+  margin-right: 5px;
+  z-index: 1001;
+  line-height: .8;
+  text-indent: 0 !important;
   border: none;
   -webkit-box-shadow: none;
   box-shadow: none; }
+  .woocommerce-cart-menu-item .cart_list li a.remove:hover {
+    background: red !important; }
 
-ul.site-header-cart.menu .widget_shopping_cart {
-  margin-bottom: 0;
-  padding: 10px 0 2px 0; }
+li#woocommerce-cart-menu-item li.mini_cart_item a {
+  border-bottom: none;
+  text-indent: 15px;
+  color: inherit; }
 
-ul.site-header-cart.menu .widget_shopping_cart .product_list_widget {
-  padding: 0 .5em;
-  max-height: 220px;
-  overflow-y: auto; }
-
-ul.site-header-cart.menu .widget_shopping_cart .product_list_widget img.attachment-shop_thumbnail {
-  width: 55px;
-  -webkit-border-radius: 5px;
-  border-radius: 5px; }
-
-ul.site-header-cart.menu .widget_shopping_cart .total {
-  padding: 10px;
-  margin: .5em 0; }
-
-ul.site-header-cart.menu .widget_shopping_cart .buttons {
-  padding: 0 .5em;
-  margin: 0; }
-
-ul.site-header-cart.menu .widget_shopping_cart .buttons a {
-  display: block;
-  width: 100%;
-  text-align: center; }
-
-ul.site-header-cart.menu .widget_shopping_cart .buttons a.remove {
-  padding-top: 2px; }
-
-.site-header-cart-container {
-  width: 100%;
-  display: block;
-  max-width: 1100px;
-  margin: 0 auto;
-  position: absolute;
-  right: 0;
-  left: 0;
-  top: 100%; }
-
-.site-header-cart-container .buttons a {
-  margin-bottom: 5px; }
-
-body.woocommerce .quantity input.input-text.qty {
-  padding: .45em; }
-
-@media only screen and (max-width: 61.063em) {
-  .menu-item-object-cart {
-    display: none; } }
+@media only screen and (min-width: 40.063em) {
+  li#woocommerce-cart-menu-item .sub-menu {
+    margin-left: -6em; } }

--- a/style.css
+++ b/style.css
@@ -1805,7 +1805,7 @@ body.no-max-width .main-navigation {
   .primer-wc-cart-menu .primer-wc-cart-sub-menu li,
   .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {
     width: 100%;
-    background: #fff; }
+    background: inherit; }
   .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {
     float: right;
     width: 250px;
@@ -1815,7 +1815,8 @@ body.no-max-width .main-navigation {
       display: block;
       float: left;
       font-style: italic;
-      padding-left: .75em; }
+      font-size: small;
+      margin-left: 2.6em; }
     .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart ul.product_list_widget {
       position: relative !important;
       left: 0;
@@ -1830,10 +1831,10 @@ body.no-max-width .main-navigation {
       text-index: 0; }
     .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart p.buttons {
       padding: .5em;
+      padding-top: 0;
       margin: 0; }
     .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item {
       padding: 0 !important;
-      margin: 0;
       width: 100%;
       padding-bottom: 5px;
       border-bottom: none;
@@ -1844,16 +1845,20 @@ body.no-max-width .main-navigation {
       transition: opacity .25s ease-out; }
       .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item img {
         width: 100%;
-        max-width: 55px; }
+        max-width: 55px;
+        margin-bottom: 0; }
       .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item a {
         border-bottom: none; }
       .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
         padding: .5em;
+        padding-bottom: 5px;
         margin: 0;
         width: 100%;
         text-indent: 0 !important; }
       .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item:hover {
         opacity: .85; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item:last-child {
+        margin-bottom: 10px; }
   .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .product_list_widget {
     border: none;
     -webkit-box-shadow: none;
@@ -1865,8 +1870,8 @@ body.no-max-width .main-navigation {
     padding: 0;
     margin-bottom: 0; }
     .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart .total {
-      margin: 0 0 10px 0;
-      padding-top: 10px;
+      margin: 0;
+      padding: 10px 0;
       text-align: center; }
     .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart .total strong {
       text-indent: 0; }
@@ -1883,7 +1888,7 @@ body.no-max-width .main-navigation {
     float: left;
     padding: 0;
     margin-top: 10px;
-    margin-left: 15px;
+    margin-left: 5px;
     text-indent: 0;
     margin-right: 5px;
     z-index: 1001;
@@ -1926,19 +1931,15 @@ body.single-product .quantity .input-text {
 body.woocommerce-cart .primer-wc-cart-sub-menu {
   display: none; }
 
-.woocommerce #content table.cart img,
 .woocommerce table.cart img,
-.woocommerce-page #content table.cart img,
 .woocommerce-page table.cart img {
   width: 100%;
   max-width: 100px;
   margin-bottom: 0; }
 
-.woocommerce #content table.cart td.actions .input-text,
 .woocommerce table.cart td.actions .input-text,
-.woocommerce-page #content table.cart td.actions .input-text,
 .woocommerce-page table.cart td.actions .input-text {
-  padding: 10px; }
+  padding: 10px !important; }
 
 .woocommerce ul.products li.product a.add_to_cart_button {
   width: 100%;

--- a/style.css
+++ b/style.css
@@ -1826,7 +1826,9 @@ ul.site-header-cart.menu {
     padding-left: .75em; }
   .widget_shopping_cart ul.product_list_widget {
     position: relative !important;
-    left: 0; }
+    left: 0;
+    max-height: 250px;
+    overflow-y: auto; }
   .widget_shopping_cart p.buttons,
   .widget_shopping_cart .total,
   .widget_shopping_cart .product_list_widget {
@@ -1918,6 +1920,26 @@ li#woocommerce-cart-menu-item li.mini_cart_item a {
   border-bottom: none;
   text-indent: 15px;
   color: inherit; }
+
+body.post-type-archive,
+body.single-product {
+  /* On Sale Badge */ }
+  body.post-type-archive span.onsale,
+  body.post-type-archive ul.products li.product .onsale,
+  body.single-product span.onsale,
+  body.single-product ul.products li.product .onsale {
+    padding: 2px 8px;
+    -webkit-border-radius: 0;
+    border-radius: 0;
+    margin: 0;
+    min-height: auto;
+    min-width: auto;
+    line-height: inherit; }
+
+body.single-product span.onsale {
+  padding: 3px 18px;
+  top: 0;
+  left: 0; }
 
 @media only screen and (min-width: 40.063em) {
   li#woocommerce-cart-menu-item .sub-menu {

--- a/style.css
+++ b/style.css
@@ -1936,6 +1936,11 @@ body.single-product .quantity .input-text {
 .woocommerce-page table.cart td.actions .input-text {
   padding: 10px; }
 
+.woocommerce ul.products li.product a.add_to_cart_button {
+  width: 100%;
+  font-size: 16px;
+  text-align: center; }
+
 @media only screen and (max-width: 40.063em) {
   .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {
     width: 100%; } }

--- a/style.css
+++ b/style.css
@@ -1568,7 +1568,6 @@ blockquote {
         z-index: 9999; } }
   .main-navigation .expand {
     font-size: 1.8rem;
-    color: white;
     position: absolute;
     right: 0;
     top: 0;
@@ -1798,128 +1797,108 @@ body.no-max-width .main-navigation {
 .widget_recent_entries .post-date {
   display: block; }
 
-.main-navigation .menu-item-object-cart:hover a {
-  background: transparent; }
-
-ul.site-header-cart.menu {
-  width: 100%;
-  max-width: 275px;
-  padding: 0;
-  list-style: none;
+.primer-wc-cart-menu .primer-wc-cart-sub-menu {
   float: right;
-  display: none;
-  position: relative;
-  z-index: 10001; }
-
-.site-footer-inner .woocommerce-cart-menu-item,
-.site-info-wrapper .woocommerce-cart-menu-item {
-  display: none; }
-
-.widget_shopping_cart {
-  float: left;
-  padding: 0 1rem;
-  margin-bottom: .5em; }
-  .widget_shopping_cart .quantity {
-    display: block;
-    float: left;
-    font-style: italic;
-    padding-left: .75em; }
-  .widget_shopping_cart ul.product_list_widget {
-    position: relative !important;
-    left: 0;
-    max-height: 250px;
-    overflow-y: auto; }
-  .widget_shopping_cart p.buttons,
-  .widget_shopping_cart .total,
-  .widget_shopping_cart .product_list_widget {
-    float: left;
-    width: 100%; }
-  .widget_shopping_cart .total strong {
-    text-index: 0; }
-  .widget_shopping_cart p.buttons {
-    padding: .5em;
-    margin: 0; }
-
-.woocommerce-cart-menu-item:hover {
-  cursor: pointer; }
-
-.woocommerce-cart-menu-item .sub-menu {
-  background: transparent; }
-
-.woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item {
-  padding: 0 !important;
-  margin: 0;
   width: 100%;
-  padding-bottom: 5px;
-  border-bottom: none;
-  padding: .5em 1em;
-  text-indent: 0;
-  opacity: 1;
-  transition: opacity .25s ease-out;
-  -moz-transition: opacity .25s ease-out;
-  -webkit-transition: opacity .25s ease-out;
-  -o-transition: opacity .25s ease-out; }
-  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item img {
-    width: 100%;
-    max-width: 55px; }
-  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a {
-    border-bottom: none; }
-  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
-    padding: .5em;
-    margin: 0;
-    width: 100%;
-    text-indent: 0 !important; }
-  .woocommerce-cart-menu-item .woocommerce.widget_shopping_cart .cart_list li.mini_cart_item:hover {
-    opacity: .85; }
-
-.woocommerce-cart-menu-item .product_list_widget {
-  border: none;
-  -webkit-box-shadow: none;
-  box-shadow: none;
-  display: inline-block;
-  left: 0 !important;
-  background: inherit; }
-
-.woocommerce-cart-menu-item .widget_shopping_cart {
-  padding: 0;
-  margin-bottom: 0; }
-  .woocommerce-cart-menu-item .widget_shopping_cart .total {
-    margin: 0 0 10px 0;
-    padding-top: 10px;
-    text-align: center; }
-  .woocommerce-cart-menu-item .widget_shopping_cart .total strong {
-    text-indent: 0; }
-  .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a {
-    text-align: center;
-    width: 100%;
-    text-indent: 0; }
-    .woocommerce-cart-menu-item .widget_shopping_cart p.buttons a:first-child {
-      margin-bottom: 5px; }
-
-.woocommerce-cart-menu-item .cart-preview-count {
-  margin-left: 8px; }
-
-.woocommerce-cart-menu-item .cart_list li a.remove {
-  position: relative !important;
-  float: left;
-  padding: 0;
-  margin-top: 10px;
-  margin-left: 15px;
-  text-indent: 0;
-  margin-right: 5px;
-  z-index: 1001;
-  line-height: .8;
-  text-indent: 0 !important;
-  border: none;
   -webkit-box-shadow: none;
   box-shadow: none; }
-  .woocommerce-cart-menu-item .cart_list li a.remove:hover {
-    background: red !important; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu li,
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {
+    width: 100%;
+    background: #fff; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {
+    float: right;
+    width: 250px;
+    -webkit-box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 3px 3px rgba(0, 0, 0, 0.2); }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .quantity {
+      display: block;
+      float: left;
+      font-style: italic;
+      padding-left: .75em; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart ul.product_list_widget {
+      position: relative !important;
+      left: 0;
+      max-height: 250px;
+      overflow-y: auto; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart p.buttons,
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .total,
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .product_list_widget {
+      float: left;
+      width: 100%; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .total strong {
+      text-index: 0; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart p.buttons {
+      padding: .5em;
+      margin: 0; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item {
+      padding: 0 !important;
+      margin: 0;
+      width: 100%;
+      padding-bottom: 5px;
+      border-bottom: none;
+      padding: .5em 1em;
+      text-indent: 0;
+      opacity: 1;
+      -webkit-transition: opacity .25s ease-out;
+      transition: opacity .25s ease-out; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item img {
+        width: 100%;
+        max-width: 55px; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item a {
+        border-bottom: none; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item a:nth-child(2) {
+        padding: .5em;
+        margin: 0;
+        width: 100%;
+        text-indent: 0 !important; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart .cart_list li.mini_cart_item:hover {
+        opacity: .85; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .product_list_widget {
+    border: none;
+    -webkit-box-shadow: none;
+    box-shadow: none;
+    display: inline-block;
+    left: 0 !important;
+    background: inherit; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart {
+    padding: 0;
+    margin-bottom: 0; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart .total {
+      margin: 0 0 10px 0;
+      padding-top: 10px;
+      text-align: center; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart .total strong {
+      text-indent: 0; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart p.buttons a {
+      text-align: center;
+      width: 100%;
+      text-indent: 0; }
+      .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .widget_shopping_cart p.buttons a:first-child {
+        margin-bottom: 5px; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .cart-preview-count {
+    margin-left: 8px; }
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .cart_list li a.remove {
+    position: relative !important;
+    float: left;
+    padding: 0;
+    margin-top: 10px;
+    margin-left: 15px;
+    text-indent: 0;
+    margin-right: 5px;
+    z-index: 1001;
+    line-height: 1;
+    text-indent: 0 !important;
+    border: none;
+    -webkit-box-shadow: none;
+    box-shadow: none; }
+    .primer-wc-cart-menu .primer-wc-cart-sub-menu .primer-wc-cart-sub-menu-item .cart_list li a.remove:hover {
+      background: red !important; }
 
-li#woocommerce-cart-menu-item li.mini_cart_item a {
-  border-bottom: none;
-  text-indent: 15px;
-  color: inherit; }
+.primer-wc-cart-menu:hover {
+  cursor: pointer; }
+  .primer-wc-cart-menu:hover a {
+    background: transparent; }
 
 body.post-type-archive,
 body.single-product {
@@ -1941,6 +1920,22 @@ body.single-product span.onsale {
   top: 0;
   left: 0; }
 
-@media only screen and (min-width: 40.063em) {
-  li#woocommerce-cart-menu-item .sub-menu {
-    margin-left: -6em; } }
+body.single-product .quantity .input-text {
+  padding: 8px; }
+
+.woocommerce #content table.cart img,
+.woocommerce table.cart img,
+.woocommerce-page #content table.cart img,
+.woocommerce-page table.cart img {
+  width: 100%;
+  margin-bottom: 0; }
+
+.woocommerce #content table.cart td.actions .input-text,
+.woocommerce table.cart td.actions .input-text,
+.woocommerce-page #content table.cart td.actions .input-text,
+.woocommerce-page table.cart td.actions .input-text {
+  padding: 10px; }
+
+@media only screen and (max-width: 40.063em) {
+  .primer-wc-cart-menu .primer-wc-cart-sub-menu .widget_shopping_cart {
+    width: 100%; } }


### PR DESCRIPTION
The new version of primer add's priorities to some functions to allow for more precise injection of content or easier management of the content flow.

This patch add's the required priorities to ensure compatibility with the latest version of primer.

**Requires:** https://github.com/godaddy/wp-primer-theme/pull/146