### PR TITLE
Fix widget title breaking hi-IN/mr

### DIFF
--- a/.dev/sass/common/_variables.scss
+++ b/.dev/sass/common/_variables.scss
@@ -15,6 +15,7 @@ $medium-up: "only screen and (min-width: #{$medium-screen})";
 $medium-down: "only screen and (max-width: #{$large-screen})";
 $medium-only: "only screen and (min-width: #{$medium-screen}) and (max-width: #{$large-screen})";
 $large-up: "only screen and (min-width: #{$large-screen})";
+$webkit: "screen and (-webkit-min-device-pixel-ratio:0)";
 
 // Typography
 $base-font-family: $primary-font;

--- a/.dev/sass/layouts/_hero.scss
+++ b/.dev/sass/layouts/_hero.scss
@@ -65,3 +65,12 @@
 		width: auto;
 	}
 }
+
+@media #{$webkit} {
+
+	html :lang(hi) h2.widget-title,
+	html :lang(mr) h2.widget-title {
+		font-family: -webkit-body;
+	}
+
+}

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1540,6 +1540,11 @@ blockquote {
     display: inline;
     width: auto; }
 
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+  html :lang(hi) h2.widget-title,
+  html :lang(mr) h2.widget-title {
+    font-family: -webkit-body; } }
+
 .main-navigation-container {
   float: left;
   position: relative; }

--- a/style.css
+++ b/style.css
@@ -1540,6 +1540,11 @@ blockquote {
     display: inline;
     width: auto; }
 
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+  html :lang(hi) h2.widget-title,
+  html :lang(mr) h2.widget-title {
+    font-family: -webkit-body; } }
+
 .main-navigation-container {
   float: right;
   position: relative; }


### PR DESCRIPTION
Related: https://github.com/godaddy/wp-velux-theme/pull/35

Two languages were not rendering properly in the header of Stout. This bug affects both Chrome and IE.

See: https://jira.godaddy.com/browse/WPDEV-667

Through some exhaustive testing I went through and tested Stout against all bundled languages within [Primer](https://github.com/godaddy/wp-primer-theme/tree/develop/languages). I found that the only two problems were `hi_IN` and `mr`.

Problem languages:
- hi_IN
- mr

**Example:**
![Sample](https://cldup.com/HDHCWjyhWo.png)

This patch introduces a new media query that is only recognized on webkit based browsers, and sets the `.widget-title` element `font-family` to `-webkit-body`. This resets the `font-family` on the element and triggers the font to render properly.

**Example - Patch Applied**:

**Chrome**:
![Chrome Fix](https://cldup.com/5CRQcM1J67.png)

**Safari**:
![Safari Fix](https://cldup.com/eep7onemIo.png)

**Firefox**:
![Firefox Fix](https://cldup.com/Z6niQArFEI.png)