### PR TITLE
Hero Image Alignment

### DIFF
--- a/.dev/sass/layouts/_header.scss
+++ b/.dev/sass/layouts/_header.scss
@@ -1,3 +1,16 @@
+.site-header {
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+}
+
+	body.admin-bar {
+		.site-header {
+			top: 32px;
+		}
+	}
+
 .site-header-wrapper {
 	@include container($container-size);
 

--- a/.dev/sass/layouts/_header.scss
+++ b/.dev/sass/layouts/_header.scss
@@ -3,13 +3,15 @@
 	top: 0;
 	left: 0;
 	right: 0;
-}
 
-	body.admin-bar {
-		.site-header {
-			top: 32px;
+	body.admin-bar & {
+		top: 32px;
+
+		@media only screen and (max-width: 782px) {
+			top: 46px;
 		}
 	}
+}
 
 .site-header-wrapper {
 	@include container($container-size);
@@ -54,6 +56,7 @@
 		display: table-cell;
 		line-height: 1.333em;
 	}
+
 	@media #{$small-only} {
 		display: table-cell;
 		line-height: 1.333em;

--- a/.dev/sass/layouts/_header.scss
+++ b/.dev/sass/layouts/_header.scss
@@ -1,4 +1,5 @@
 .site-header {
+	position: absolute;
 	top: 0;
 	left: 0;
 	right: 0;

--- a/.dev/sass/layouts/_header.scss
+++ b/.dev/sass/layouts/_header.scss
@@ -1,5 +1,4 @@
 .site-header {
-	position: absolute;
 	top: 0;
 	left: 0;
 	right: 0;

--- a/.dev/sass/layouts/_hero.scss
+++ b/.dev/sass/layouts/_hero.scss
@@ -1,6 +1,5 @@
 .hero {
 	color: $background-color;
-	margin-top: -100px;
 	min-height: 300px;
 	width: 100%;
 	padding-top: 100px;

--- a/.dev/sass/layouts/_hero.scss
+++ b/.dev/sass/layouts/_hero.scss
@@ -4,7 +4,7 @@
 	width: 100%;
 	padding-top: 100px;
 	background-size: cover;
-	background-position: center top;
+	background-position: center;
 	background-repeat: no-repeat;
 
 	.hero-inner {

--- a/.dev/sass/layouts/_hero.scss
+++ b/.dev/sass/layouts/_hero.scss
@@ -2,7 +2,6 @@
 	color: $background-color;
 	min-height: 300px;
 	width: 100%;
-	padding-top: 100px;
 	background-size: cover;
 	background-position: center;
 	background-repeat: no-repeat;

--- a/.dev/sass/layouts/_hero.scss
+++ b/.dev/sass/layouts/_hero.scss
@@ -10,7 +10,7 @@
 		@include container($container-size);
 
 		margin: 0 auto;
-		padding: 9% 2em;
+		padding: 121px 2em;
 
 		@media screen and (max-width: 900px) {
 			max-width: none;

--- a/.dev/sass/layouts/_hero.scss
+++ b/.dev/sass/layouts/_hero.scss
@@ -2,6 +2,7 @@
 	color: $background-color;
 	min-height: 300px;
 	width: 100%;
+	padding-top: 100px;
 	background-size: cover;
 	background-position: center;
 	background-repeat: no-repeat;

--- a/.dev/sass/layouts/_menu.scss
+++ b/.dev/sass/layouts/_menu.scss
@@ -142,7 +142,7 @@
 	a {
 		display: block;
 		text-decoration: none;
-		padding: 2em 1em;
+		padding: calc(2em + 1px) 1em 2em;
 		color: $header-textcolor;
 
 		@media #{$small-only} {

--- a/.dev/sass/layouts/_menu.scss
+++ b/.dev/sass/layouts/_menu.scss
@@ -9,6 +9,7 @@
 
 .main-navigation {
 	@include container($container-size);
+
 	display: none;
 
 	&.open {
@@ -150,7 +151,6 @@
 			padding-top: 1.2em;
 			padding-bottom: 1.2em;
 		}
-
 	}
 
 	.current_page_item > a,

--- a/.dev/sass/layouts/_menu.scss
+++ b/.dev/sass/layouts/_menu.scss
@@ -87,15 +87,7 @@
 		@media #{$medium-up} {
 			position: relative;
 			float: left;
-
-			&:first-child > a {
-				border-top: 1px solid rgba(0, 0, 0, 0.1);
-			}
 		}
-	}
-
-	#menu-main-menu > li:first-child > a {
-		border-top: 1px solid rgba(0, 0, 0, 0.1);
 	}
 
 	ul {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,11 +59,33 @@ module.exports = function( grunt ) {
 			}
 		},
 
+		jshint: {
+			assets: [ 'assets/js/*.js', '!assets/js/*.min.js' ],
+			gruntfile: [ 'Gruntfile.js' ]
+		},
+
+		uglify: {
+			options: {
+				ASCIIOnly: true
+			},
+			assets: {
+				expand: true,
+				cwd: 'assets/js/',
+				src: [ '**/*.js', '!**/*.min.js' ],
+				dest: 'assets/js/',
+				ext: '.min.js'
+			}
+		},
+
 		watch: {
 			css: {
 				files: '.dev/sass/**/*.scss',
 				tasks: [ 'sass','autoprefixer','cssjanus' ]
-			}
+			},
+			js: {
+				files: 'assets/js/**/*.js',
+				tasks: [ 'jshint', 'uglify' ]
+			},
 		},
 
 		replace: {
@@ -112,7 +134,7 @@ module.exports = function( grunt ) {
 
 	require( 'matchdep' ).filterDev( 'grunt-*' ).forEach( grunt.loadNpmTasks );
 
-	grunt.registerTask( 'default', [ 'sass', 'autoprefixer', 'cssjanus' ] );
+	grunt.registerTask( 'default', [ 'sass', 'autoprefixer', 'cssjanus', 'jshint', 'uglify' ] );
 	grunt.registerTask( 'version', [ 'replace' ] );
 
 };

--- a/assets/js/stout-hero.js
+++ b/assets/js/stout-hero.js
@@ -1,0 +1,13 @@
+( function( $ ) {
+
+	function tweak_hero_padding() {
+
+		$( '.hero' ).css( 'padding-top', $( '#masthead' ).height() );
+
+	}
+
+	$( document ).ready( tweak_hero_padding );
+
+	$( window ).on( 'resize', tweak_hero_padding );
+
+} )( jQuery );

--- a/assets/js/stout-hero.min.js
+++ b/assets/js/stout-hero.min.js
@@ -1,0 +1,1 @@
+!function(a){function b(){a(".hero").css("padding-top",a("#masthead").height())}a(document).ready(b),a(window).on("resize",b)}(jQuery);

--- a/functions.php
+++ b/functions.php
@@ -422,3 +422,18 @@ function stout_color_schemes( $color_schemes ) {
 
 }
 add_filter( 'primer_color_schemes', 'stout_color_schemes' );
+
+/**
+ * Enqueue stout hero scripts.
+ *
+ * @link  https://codex.wordpress.org/Function_Reference/wp_enqueue_script
+ * @since NEXT
+ */
+function stout_hero_scripts() {
+
+	$suffix = SCRIPT_DEBUG ? '' : '.min';
+
+	wp_enqueue_script( 'stout-hero', get_stylesheet_directory_uri() . "/assets/js/stout-hero{$suffix}.js", array( 'jquery' ), PRIMER_VERSION, true );
+
+}
+add_action( 'wp_enqueue_scripts', 'stout_hero_scripts' );

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "grunt-autoprefixer": "~3.0.4",
     "grunt-contrib-watch": "~1.0.0",
     "grunt-cssjanus": "~0.3.2",
+    "grunt-contrib-jshint": "^1.1.0",
+    "grunt-contrib-uglify": "^2.1.0",
     "grunt-dev-update": "~2.0.0",
     "grunt-sass": "^1.2.0",
     "grunt-text-replace": "^0.4.0",

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1504,7 +1504,7 @@ body.admin-bar .site-header {
   padding-top: 100px;
   -webkit-background-size: cover;
   background-size: cover;
-  background-position: center top;
+  background-position: center;
   background-repeat: no-repeat; }
   .hero .hero-inner {
     max-width: 1100px;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1458,9 +1458,11 @@ blockquote {
   top: 0;
   right: 0;
   left: 0; }
-
-body.admin-bar .site-header {
-  top: 32px; }
+  body.admin-bar .site-header {
+    top: 32px; }
+    @media only screen and (max-width: 782px) {
+      body.admin-bar .site-header {
+        top: 46px; } }
 
 .site-header-wrapper {
   max-width: 1100px;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1434,6 +1434,15 @@ blockquote {
       margin-top: 0;
       text-align: right; } }
 
+.site-header {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0; }
+
+body.admin-bar .site-header {
+  top: 32px; }
+
 .site-header-wrapper {
   max-width: 1100px;
   margin-right: auto;
@@ -1490,7 +1499,6 @@ blockquote {
 
 .hero {
   color: #ffffff;
-  margin-top: -100px;
   min-height: 300px;
   width: 100%;
   padding-top: 100px;
@@ -1607,11 +1615,7 @@ blockquote {
   @media only screen and (min-width: 40.063em) {
     .main-navigation li {
       position: relative;
-      float: right; }
-      .main-navigation li:first-child > a {
-        border-top: 1px solid rgba(0, 0, 0, 0.1); } }
-  .main-navigation #menu-main-menu > li:first-child > a {
-    border-top: 1px solid rgba(0, 0, 0, 0.1); }
+      float: right; } }
   .main-navigation ul {
     list-style: none;
     margin: 0;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1454,7 +1454,6 @@ blockquote {
       text-align: right; } }
 
 .site-header {
-  position: absolute;
   top: 0;
   right: 0;
   left: 0; }
@@ -1522,7 +1521,6 @@ blockquote {
   color: #ffffff;
   min-height: 300px;
   width: 100%;
-  padding-top: 100px;
   -webkit-background-size: cover;
   background-size: cover;
   background-position: center;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1675,7 +1675,8 @@ blockquote {
   .main-navigation a {
     display: block;
     text-decoration: none;
-    padding: 2em 1em;
+    padding: -webkit-calc(2em + 1px) 1em 2em;
+    padding: calc(2em + 1px) 1em 2em;
     color: #252f31; }
     @media only screen and (max-width: 40.063em) {
       .main-navigation a {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1454,6 +1454,7 @@ blockquote {
       text-align: right; } }
 
 .site-header {
+  position: absolute;
   top: 0;
   right: 0;
   left: 0; }
@@ -1521,6 +1522,7 @@ blockquote {
   color: #ffffff;
   min-height: 300px;
   width: 100%;
+  padding-top: 100px;
   -webkit-background-size: cover;
   background-size: cover;
   background-position: center;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1530,7 +1530,7 @@ blockquote {
     margin-right: auto;
     margin-left: auto;
     margin: 0 auto;
-    padding: 9% 2em; }
+    padding: 121px 2em; }
     .hero .hero-inner:after {
       content: " ";
       display: block;

--- a/style.css
+++ b/style.css
@@ -1458,9 +1458,11 @@ blockquote {
   top: 0;
   left: 0;
   right: 0; }
-
-body.admin-bar .site-header {
-  top: 32px; }
+  body.admin-bar .site-header {
+    top: 32px; }
+    @media only screen and (max-width: 782px) {
+      body.admin-bar .site-header {
+        top: 46px; } }
 
 .site-header-wrapper {
   max-width: 1100px;

--- a/style.css
+++ b/style.css
@@ -1454,7 +1454,6 @@ blockquote {
       text-align: left; } }
 
 .site-header {
-  position: absolute;
   top: 0;
   left: 0;
   right: 0; }
@@ -1522,7 +1521,6 @@ blockquote {
   color: #ffffff;
   min-height: 300px;
   width: 100%;
-  padding-top: 100px;
   -webkit-background-size: cover;
   background-size: cover;
   background-position: center;

--- a/style.css
+++ b/style.css
@@ -1434,6 +1434,15 @@ blockquote {
       margin-top: 0;
       text-align: left; } }
 
+.site-header {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0; }
+
+body.admin-bar .site-header {
+  top: 32px; }
+
 .site-header-wrapper {
   max-width: 1100px;
   margin-left: auto;
@@ -1490,7 +1499,6 @@ blockquote {
 
 .hero {
   color: #ffffff;
-  margin-top: -100px;
   min-height: 300px;
   width: 100%;
   padding-top: 100px;
@@ -1607,11 +1615,7 @@ blockquote {
   @media only screen and (min-width: 40.063em) {
     .main-navigation li {
       position: relative;
-      float: left; }
-      .main-navigation li:first-child > a {
-        border-top: 1px solid rgba(0, 0, 0, 0.1); } }
-  .main-navigation #menu-main-menu > li:first-child > a {
-    border-top: 1px solid rgba(0, 0, 0, 0.1); }
+      float: left; } }
   .main-navigation ul {
     list-style: none;
     margin: 0;

--- a/style.css
+++ b/style.css
@@ -1504,7 +1504,7 @@ body.admin-bar .site-header {
   padding-top: 100px;
   -webkit-background-size: cover;
   background-size: cover;
-  background-position: center top;
+  background-position: center;
   background-repeat: no-repeat; }
   .hero .hero-inner {
     max-width: 1100px;

--- a/style.css
+++ b/style.css
@@ -1454,6 +1454,7 @@ blockquote {
       text-align: left; } }
 
 .site-header {
+  position: absolute;
   top: 0;
   left: 0;
   right: 0; }
@@ -1521,6 +1522,7 @@ blockquote {
   color: #ffffff;
   min-height: 300px;
   width: 100%;
+  padding-top: 100px;
   -webkit-background-size: cover;
   background-size: cover;
   background-position: center;

--- a/style.css
+++ b/style.css
@@ -1675,7 +1675,8 @@ blockquote {
   .main-navigation a {
     display: block;
     text-decoration: none;
-    padding: 2em 1em;
+    padding: -webkit-calc(2em + 1px) 1em 2em;
+    padding: calc(2em + 1px) 1em 2em;
     color: #252f31; }
     @media only screen and (max-width: 40.063em) {
       .main-navigation a {

--- a/style.css
+++ b/style.css
@@ -1530,7 +1530,7 @@ blockquote {
     margin-left: auto;
     margin-right: auto;
     margin: 0 auto;
-    padding: 9% 2em; }
+    padding: 121px 2em; }
     .hero .hero-inner:after {
       content: " ";
       display: block;


### PR DESCRIPTION
@fjarrett Please review.

This PR resolves #10 

Along with that fix, there was a small bug where the first `li` in the main navigation had a top border (not sure if this was intentional or not). When the nav wrapped, it was much more obvious.

Before Patch:
<img src="https://cldup.com/UNWqkqk7Lz.png" width="35%">

After Patch:
<img src="https://cldup.com/8LWpLzBGvr.png" width="35%">

Finally, this PR centers the hero background image, which better reflects the mobile layout (the image is centered on mobile devices). This also works well when no hero widget is is being used, or when on a single page.

Example (pre-patch):
![example](https://cldup.com/Mk6Kguaa1R.png)

vs.

![example](https://cldup.com/rV3LXR9Emk.png)