### PR TITLE
Prevent i10n WooCommerce button overlap/overflow, tweak font size, remove on sale comment

### DIFF
--- a/.dev/sass/compat/woocommerce.scss
+++ b/.dev/sass/compat/woocommerce.scss
@@ -159,9 +159,21 @@
 	}
 }
 
+body.primer-woocommerce-l10n.woocommerce ul.products li.product .button,
+.woocommerce a.added_to_cart {
+	max-width: 100%;
+	white-space: normal;
+	text-align: center;
+	display: block;
+
+	@media #{$large-up} {
+		font-size: 0.75rem;
+	}
+
+}
+
 body.post-type-archive,
 body.single-product {
-	/* On Sale Badge */
 	span.onsale,
 	ul.products li.product .onsale {
 		padding: 2px 8px;

--- a/.dev/sass/layouts/_menu.scss
+++ b/.dev/sass/layouts/_menu.scss
@@ -188,6 +188,58 @@
 	}
 }
 
+.navigation.pagination {
+	clear: both;
+	margin: 0 0 1.5em;
+
+	.nav-links {
+		text-align: center;
+
+		.page-numbers {
+			display: inline-block;
+			border: none;
+			border-radius: 3px;
+			line-height: 1;
+			margin: 0 0.25em;
+			padding: 0.5em 0.75em;
+			white-space: nowrap;
+
+			&.dots {
+				background: none;
+			}
+
+			&.current {
+				color: $base-background-color;
+				background-color: $link-color;
+			}
+		}
+	}
+
+	.paging-nav-text {
+		display: none;
+	}
+
+	@media #{$small-only} {
+
+		.paging-nav-text {
+			display: inline-block;
+			font-size: 0.9rem;
+			font-weight: normal;
+			color: $main-text-color;
+		}
+
+		.nav-links {
+			float: right;
+
+			.page-numbers {
+				&:not(.prev, .next) {
+					display: none;
+				}
+			}
+		}
+	}
+}
+
 body.no-max-width .main-navigation {
 	max-width: none;
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1700,6 +1700,38 @@ blockquote {
       .main-navigation .sub-menu .menu-item-has-children > a::after {
         display: inline; } }
 
+.navigation.pagination {
+  clear: both;
+  margin: 0 0 1.5em; }
+  .navigation.pagination .nav-links {
+    text-align: center; }
+    .navigation.pagination .nav-links .page-numbers {
+      display: inline-block;
+      border: none;
+      -webkit-border-radius: 3px;
+      border-radius: 3px;
+      line-height: 1;
+      margin: 0 0.25em;
+      padding: 0.5em 0.75em;
+      white-space: nowrap; }
+      .navigation.pagination .nav-links .page-numbers.dots {
+        background: none; }
+      .navigation.pagination .nav-links .page-numbers.current {
+        color: #e3eaeb;
+        background-color: #e3ae30; }
+  .navigation.pagination .paging-nav-text {
+    display: none; }
+  @media only screen and (max-width: 40.063em) {
+    .navigation.pagination .paging-nav-text {
+      display: inline-block;
+      font-size: 0.9rem;
+      font-weight: normal;
+      color: #252f31; }
+    .navigation.pagination .nav-links {
+      float: left; }
+      .navigation.pagination .nav-links .page-numbers:not(.prev):not(.next) {
+        display: none; } }
+
 body.no-max-width .main-navigation {
   max-width: none; }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1959,20 +1959,28 @@ body.no-max-width .main-navigation {
     .primer-wc-cart-menu:hover a {
       background: transparent; }
 
-body.post-type-archive,
-body.single-product {
-  /* On Sale Badge */ }
-  body.post-type-archive span.onsale,
-  body.post-type-archive ul.products li.product .onsale,
-  body.single-product span.onsale,
-  body.single-product ul.products li.product .onsale {
-    padding: 2px 8px;
-    -webkit-border-radius: 0;
-    border-radius: 0;
-    margin: 0;
-    min-height: auto;
-    min-width: auto;
-    line-height: inherit; }
+body.primer-woocommerce-l10n.woocommerce ul.products li.product .button, body.primer-woocommerce-l10n.woocommerce ul.products li.product .social-menu a, .social-menu body.primer-woocommerce-l10n.woocommerce ul.products li.product a,
+.woocommerce a.added_to_cart {
+  max-width: 100%;
+  white-space: normal;
+  text-align: center;
+  display: block; }
+  @media only screen and (min-width: 61.063em) {
+    body.primer-woocommerce-l10n.woocommerce ul.products li.product .button, body.primer-woocommerce-l10n.woocommerce ul.products li.product .social-menu a, .social-menu body.primer-woocommerce-l10n.woocommerce ul.products li.product a,
+    .woocommerce a.added_to_cart {
+      font-size: 0.75rem; } }
+
+body.post-type-archive span.onsale,
+body.post-type-archive ul.products li.product .onsale,
+body.single-product span.onsale,
+body.single-product ul.products li.product .onsale {
+  padding: 2px 8px;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+  margin: 0;
+  min-height: auto;
+  min-width: auto;
+  line-height: inherit; }
 
 body.single-product span.onsale {
   padding: 3px 18px;

--- a/style.css
+++ b/style.css
@@ -1959,20 +1959,28 @@ body.no-max-width .main-navigation {
     .primer-wc-cart-menu:hover a {
       background: transparent; }
 
-body.post-type-archive,
-body.single-product {
-  /* On Sale Badge */ }
-  body.post-type-archive span.onsale,
-  body.post-type-archive ul.products li.product .onsale,
-  body.single-product span.onsale,
-  body.single-product ul.products li.product .onsale {
-    padding: 2px 8px;
-    -webkit-border-radius: 0;
-    border-radius: 0;
-    margin: 0;
-    min-height: auto;
-    min-width: auto;
-    line-height: inherit; }
+body.primer-woocommerce-l10n.woocommerce ul.products li.product .button, body.primer-woocommerce-l10n.woocommerce ul.products li.product .social-menu a, .social-menu body.primer-woocommerce-l10n.woocommerce ul.products li.product a,
+.woocommerce a.added_to_cart {
+  max-width: 100%;
+  white-space: normal;
+  text-align: center;
+  display: block; }
+  @media only screen and (min-width: 61.063em) {
+    body.primer-woocommerce-l10n.woocommerce ul.products li.product .button, body.primer-woocommerce-l10n.woocommerce ul.products li.product .social-menu a, .social-menu body.primer-woocommerce-l10n.woocommerce ul.products li.product a,
+    .woocommerce a.added_to_cart {
+      font-size: 0.75rem; } }
+
+body.post-type-archive span.onsale,
+body.post-type-archive ul.products li.product .onsale,
+body.single-product span.onsale,
+body.single-product ul.products li.product .onsale {
+  padding: 2px 8px;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+  margin: 0;
+  min-height: auto;
+  min-width: auto;
+  line-height: inherit; }
 
 body.single-product span.onsale {
   padding: 3px 18px;

--- a/style.css
+++ b/style.css
@@ -1700,6 +1700,38 @@ blockquote {
       .main-navigation .sub-menu .menu-item-has-children > a::after {
         display: inline; } }
 
+.navigation.pagination {
+  clear: both;
+  margin: 0 0 1.5em; }
+  .navigation.pagination .nav-links {
+    text-align: center; }
+    .navigation.pagination .nav-links .page-numbers {
+      display: inline-block;
+      border: none;
+      -webkit-border-radius: 3px;
+      border-radius: 3px;
+      line-height: 1;
+      margin: 0 0.25em;
+      padding: 0.5em 0.75em;
+      white-space: nowrap; }
+      .navigation.pagination .nav-links .page-numbers.dots {
+        background: none; }
+      .navigation.pagination .nav-links .page-numbers.current {
+        color: #e3eaeb;
+        background-color: #e3ae30; }
+  .navigation.pagination .paging-nav-text {
+    display: none; }
+  @media only screen and (max-width: 40.063em) {
+    .navigation.pagination .paging-nav-text {
+      display: inline-block;
+      font-size: 0.9rem;
+      font-weight: normal;
+      color: #252f31; }
+    .navigation.pagination .nav-links {
+      float: right; }
+      .navigation.pagination .nav-links .page-numbers:not(.prev):not(.next) {
+        display: none; } }
+
 body.no-max-width .main-navigation {
   max-width: none; }
 


### PR DESCRIPTION
@fjarrett Please review.

Prevent button overlaps, adjust font size for WooCommerce compat.

Related https://github.com/godaddy/wp-primer-theme/pull/167

![example](https://cldup.com/ts5lF50k9e.png)