### PR TITLE
WordPress 4.9.6 Support

### DIFF
--- a/.dev/sass/components/_comments.scss
+++ b/.dev/sass/components/_comments.scss
@@ -37,4 +37,23 @@
 			clear: both;
 		}
 	}
+
+	.comment-form-cookies-consent {
+		display: flex;
+		line-height: 16px;
+
+		#wp-comment-cookies-consent {
+			display: inline;
+			width: auto;
+			margin: 0 10px 0 0;
+
+			+ label[for="wp-comment-cookies-consent"] {
+				line-height: 1.2;
+			}
+
+			@media #{$small-only} {
+				margin-top: 2px;
+			}
+		}
+	}
 }

--- a/.dev/sass/layouts/_footer.scss
+++ b/.dev/sass/layouts/_footer.scss
@@ -88,9 +88,21 @@
 	padding-bottom: 2em;
 	text-align: center;
 
+	.privacy-policy-link {
+		display: inline-block;
+		margin-top: 10px;
+		margin-bottom: 10px;
+	}
+
 	@media #{$large-up} {
 		text-align: right;
+		margin-bottom: 5px;
 
+		.privacy-policy-link {
+			@include span(9);
+			margin-top: 0;
+			margin-bottom: 5px;
+		}
 		.site-info-text {
 			@include span(9);
 		}
@@ -130,6 +142,7 @@
 
 .social-menu {
 	margin-top: 1.5em;
+	display: inline;
 
 	ul {
 		list-style: none;
@@ -143,5 +156,6 @@
 	@media #{$large-up} {
 		margin-top: 0;
 		text-align: left;
+		display: block;
 	}
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -714,6 +714,23 @@ input[type="reset"] {
   .comments-area .comment .comment-content {
     clear: both; }
 
+.comments-area .comment-form-cookies-consent {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: flex;
+  line-height: 16px; }
+  .comments-area .comment-form-cookies-consent #wp-comment-cookies-consent {
+    display: inline;
+    width: auto;
+    margin: 0 0 0 10px; }
+    .comments-area .comment-form-cookies-consent #wp-comment-cookies-consent + label[for="wp-comment-cookies-consent"] {
+      line-height: 1.2; }
+    @media only screen and (max-width: 40.063em) {
+      .comments-area .comment-form-cookies-consent #wp-comment-cookies-consent {
+        margin-top: 2px; } }
+
 .nf-response-msg,
 .widget-area .nf-response-msg {
   font-weight: bold; }
@@ -1415,9 +1432,21 @@ blockquote {
     content: " ";
     display: block;
     clear: both; }
+  .site-info .privacy-policy-link {
+    display: inline-block;
+    margin-top: 10px;
+    margin-bottom: 10px; }
   @media only screen and (min-width: 61.063em) {
     .site-info {
-      text-align: left; }
+      text-align: left;
+      margin-bottom: 5px; }
+      .site-info .privacy-policy-link {
+        width: 72.22222%;
+        float: right;
+        margin-right: 1.38889%;
+        margin-left: 1.38889%;
+        margin-top: 0;
+        margin-bottom: 5px; }
       .site-info .site-info-text {
         width: 72.22222%;
         float: right;
@@ -1448,7 +1477,8 @@ blockquote {
           color: shade(#404c4e, 25%); }
 
 .social-menu {
-  margin-top: 1.5em; }
+  margin-top: 1.5em;
+  display: inline; }
   .social-menu ul {
     list-style: none;
     margin: 0;
@@ -1458,7 +1488,8 @@ blockquote {
   @media only screen and (min-width: 61.063em) {
     .social-menu {
       margin-top: 0;
-      text-align: right; } }
+      text-align: right;
+      display: block; } }
 
 .site-header.video-header + .hero {
   overflow: hidden;

--- a/style.css
+++ b/style.css
@@ -714,6 +714,23 @@ input[type="reset"] {
   .comments-area .comment .comment-content {
     clear: both; }
 
+.comments-area .comment-form-cookies-consent {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: flex;
+  line-height: 16px; }
+  .comments-area .comment-form-cookies-consent #wp-comment-cookies-consent {
+    display: inline;
+    width: auto;
+    margin: 0 10px 0 0; }
+    .comments-area .comment-form-cookies-consent #wp-comment-cookies-consent + label[for="wp-comment-cookies-consent"] {
+      line-height: 1.2; }
+    @media only screen and (max-width: 40.063em) {
+      .comments-area .comment-form-cookies-consent #wp-comment-cookies-consent {
+        margin-top: 2px; } }
+
 .nf-response-msg,
 .widget-area .nf-response-msg {
   font-weight: bold; }
@@ -1415,9 +1432,21 @@ blockquote {
     content: " ";
     display: block;
     clear: both; }
+  .site-info .privacy-policy-link {
+    display: inline-block;
+    margin-top: 10px;
+    margin-bottom: 10px; }
   @media only screen and (min-width: 61.063em) {
     .site-info {
-      text-align: right; }
+      text-align: right;
+      margin-bottom: 5px; }
+      .site-info .privacy-policy-link {
+        width: 72.22222%;
+        float: left;
+        margin-left: 1.38889%;
+        margin-right: 1.38889%;
+        margin-top: 0;
+        margin-bottom: 5px; }
       .site-info .site-info-text {
         width: 72.22222%;
         float: left;
@@ -1448,7 +1477,8 @@ blockquote {
           color: shade(#404c4e, 25%); }
 
 .social-menu {
-  margin-top: 1.5em; }
+  margin-top: 1.5em;
+  display: inline; }
   .social-menu ul {
     list-style: none;
     margin: 0;
@@ -1458,7 +1488,8 @@ blockquote {
   @media only screen and (min-width: 61.063em) {
     .social-menu {
       margin-top: 0;
-      text-align: left; } }
+      text-align: left;
+      display: block; } }
 
 .site-header.video-header + .hero {
   overflow: hidden;


### PR DESCRIPTION
WordPress 4.9.6 introduced Privacy Policy pages and new comment checkboxes. We should generate a Privacy Policy link in the site footer if one is set, and have a customizer checkbox toggle to enable/disable visibility.

Additionally, a new checkbox, a commenter cookie opt-in, was introduced into the comment forms. We will need to introduce styles for those.

Related Primer PR:
godaddy/wp-primer-theme#254